### PR TITLE
align version to Camel

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     </parent>
 
     <groupId>org.apache.camel</groupId>
-    <version>0.2-SNAPSHOT</version>
+    <version>4.7.0-SNAPSHOT</version>
     <artifactId>camel-upgrade-recipes</artifactId>
 
     <name>Camel Upgrades Recipes</name>
@@ -63,7 +63,7 @@
             <post>commits@camel.apache.org</post>
         </mailingList>
     </mailingLists>
-    
+
    <scm>
         <connection>scm:git:http://gitbox.apache.org/repos/asf/camel-upgrade-recipes.git</connection>
         <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/camel-upgrade-recipes.git</developerConnection>


### PR DESCRIPTION
fixes https://issues.apache.org/jira/browse/CAMEL-20959

Version in pom.xml is changed to 4.4.0-SNAPSHOT as the recipes are migrating to Camel 4.4.x