### PR TITLE
Remove unnecessary test dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -314,12 +314,6 @@
                                 <!-- camel 4.0 dependencies-->
                                 <artifactItem>
                                     <groupId>org.apache.camel</groupId>
-                                    <artifactId>camel-api</artifactId>
-                                    <version>${camel4.0-version}</version>
-                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>org.apache.camel</groupId>
                                     <artifactId>camel-base</artifactId>
                                     <version>${camel4.0-version}</version>
                                     <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
@@ -333,12 +327,6 @@
                                 <artifactItem>
                                     <groupId>org.apache.camel</groupId>
                                     <artifactId>camel-endpointdsl</artifactId>
-                                    <version>${camel4.0-version}</version>
-                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>org.apache.camel</groupId>
-                                    <artifactId>camel-core-model</artifactId>
                                     <version>${camel4.0-version}</version>
                                     <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
                                 </artifactItem>
@@ -362,32 +350,8 @@
                                 </artifactItem>
                                 <artifactItem>
                                     <groupId>org.apache.camel</groupId>
-                                    <artifactId>camel-support</artifactId>
-                                    <version>${camel4.0-version}</version>
-                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>org.apache.camel</groupId>
                                     <artifactId>camel-tracing</artifactId>
                                     <version>${camel4.0-version}</version>
-                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>org.apache.camel</groupId>
-                                    <artifactId>camel-util</artifactId>
-                                    <version>${camel4.0-version}</version>
-                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>org.apache.camel</groupId>
-                                    <artifactId>camel-base-engine</artifactId>
-                                    <version>${camel4.4-version}</version>
-                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>org.apache.camel</groupId>
-                                    <artifactId>camel-api</artifactId>
-                                    <version>${camel4.4-version}</version>
                                     <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
                                 </artifactItem>
                                 <artifactItem>
@@ -411,31 +375,7 @@
                                 <!-- 4.5-->
                                 <artifactItem>
                                     <groupId>org.apache.camel</groupId>
-                                    <artifactId>camel-api</artifactId>
-                                    <version>${camel4.5-version}</version>
-                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>org.apache.camel</groupId>
                                     <artifactId>camel-elasticsearch</artifactId>
-                                    <version>${camel4.5-version}</version>
-                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>org.apache.camel</groupId>
-                                    <artifactId>camel-base-engine</artifactId>
-                                    <version>${camel4.5-version}</version>
-                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>org.apache.camel</groupId>
-                                    <artifactId>camel-spring-redis</artifactId>
-                                    <version>${camel4.5-version}</version>
-                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>org.apache.camel</groupId>
-                                    <artifactId>camel-opensearch</artifactId>
                                     <version>${camel4.5-version}</version>
                                     <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
                                 </artifactItem>
@@ -452,18 +392,6 @@
                                     <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
                                 </artifactItem>
                                 <!-- 4.6-->
-                                <artifactItem>
-                                    <groupId>org.apache.camel</groupId>
-                                    <artifactId>camel-base-engine</artifactId>
-                                    <version>${camel4.6-version}</version>
-                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>org.apache.camel</groupId>
-                                    <artifactId>camel-api</artifactId>
-                                    <version>${camel4.6-version}</version>
-                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
-                                </artifactItem>
                                 <artifactItem>
                                     <groupId>org.apache.camel</groupId>
                                     <artifactId>camel-http-common</artifactId>

--- a/src/test/java/org/apache/camel/updates/CamelTestUtil.java
+++ b/src/test/java/org/apache/camel/updates/CamelTestUtil.java
@@ -16,8 +16,12 @@
  */
 package org.apache.camel.updates;
 
+import java.io.File;
+import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.openrewrite.InMemoryExecutionContext;
@@ -79,7 +83,17 @@ public class CamelTestUtil {
     public static Parser.Builder parserFromClasspath(CamelVersion from, String... classpath) {
         List<String> resources = Arrays.stream(classpath).map(cl -> {
             if (cl.startsWith("camel-")) {
-                return cl + "-" + from.getVersion();
+                String maxVersion = cl + "-" +  from.getVersion();
+                //find the highest version lesser or equals the required one
+                Optional<String> dependency = Arrays.stream(Paths.get("target/test-classes/META-INF/rewrite/classpath").toFile().listFiles())
+                        .filter(f -> f.getName().startsWith(cl))
+                        .map(f -> f.getName().substring(0, f.getName().lastIndexOf(".")))
+                        //filter out or higher version the requested
+                        .filter(f -> f.compareTo(maxVersion) <= 0)
+                        .sorted(Comparator.reverseOrder())
+                        .findFirst();
+
+                return dependency.orElse(cl);
             }
             return cl;
         }).collect(Collectors.toList());


### PR DESCRIPTION
fixes https://issues.apache.org/jira/browse/CAMEL-21111

Small change in resolving test dependencies (for the openrewrite junit tests) allows to remove 10+ test dependencies.