### PR TITLE
 Upgrading Camel 4.7 to 4.8

### DIFF
--- a/src/main/resources/META-INF/rewrite/4.8.yaml
+++ b/src/main/resources/META-INF/rewrite/4.8.yaml
@@ -1,0 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#####
+# Rules coming from https://camel.apache.org/manual/camel-4x-upgrade-guide-4_8.html#_upgrading_camel_4_7_to_4_8
+# None of the migrations can be covered by the automation migrations.
+#####


### PR DESCRIPTION
An empty recipes file for upgrade to Camel 4.8, as there is no need/way to cover migrations by the automated recipes.