### PR TITLE
Migration from Camel 4.8 to 4.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,7 @@
         <camel4.4-version>4.4.2</camel4.4-version>
         <camel4.5-version>4.5.0</camel4.5-version>
         <camel4.6-version>4.6.0</camel4.6-version>
+        <camel4.8-version>4.8.0</camel4.8-version>
 
         <rewrite-recipe-bom.version>2.10.0</rewrite-recipe-bom.version>
 
@@ -202,6 +203,19 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>${lombok.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-core-engine</artifactId>
+            <version>${camel4.8-version}</version>
+        </dependency>
+
+
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-core-languages</artifactId>
+            <version>${camel4.8-version}</version>
         </dependency>
 
     </dependencies>
@@ -408,6 +422,55 @@
                                     <groupId>jakarta.servlet</groupId>
                                     <artifactId>jakarta.servlet-api</artifactId>
                                     <version>6.0.0</version>
+                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
+                                </artifactItem>
+                                <!-- 4.8 -->
+                                <artifactItem>
+                                    <groupId>org.apache.camel</groupId>
+                                    <artifactId>camel-api</artifactId>
+                                    <version>${camel4.8-version}</version>
+                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.camel</groupId>
+                                    <artifactId>camel-core-model</artifactId>
+                                    <version>${camel4.8-version}</version>
+                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.camel</groupId>
+                                    <artifactId>camel-debezium-db2</artifactId>
+                                    <version>${camel4.8-version}</version>
+                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.camel</groupId>
+                                    <artifactId>camel-debezium-mongodb</artifactId>
+                                    <version>${camel4.8-version}</version>
+                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.camel</groupId>
+                                    <artifactId>camel-debezium-oracle</artifactId>
+                                    <version>${camel4.8-version}</version>
+                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.camel</groupId>
+                                    <artifactId>camel-debezium-mysql</artifactId>
+                                    <version>${camel4.8-version}</version>
+                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.camel</groupId>
+                                    <artifactId>camel-debezium-postgres</artifactId>
+                                    <version>${camel4.8-version}</version>
+                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.camel</groupId>
+                                    <artifactId>camel-debezium-sqlserver</artifactId>
+                                    <version>${camel4.8-version}</version>
                                     <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
                                 </artifactItem>
                             </artifactItems>

--- a/release_notes.adoc
+++ b/release_notes.adoc
@@ -1,0 +1,45 @@
+= Release notes
+
+
+
+[%autowidth,stripes=hover]
+|===
+| from | to | chapter
+
+| 4.8.0 | 4.9.0 | <<_4_9_0>>
+
+|===
+
+=== 4.9.0
+
+Upgrading Camel 4.8 to 4.9 (described by the https://camel.apache.org/manual/camel-4x-upgrade-guide-4_9.html[guide])
+
+Not all of the migrations could be covered by the openrewrite recipes.
+See the table for more details:
+
+[%autowidth,stripes=hover]
+|===
+| component | status | comment
+
+
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_9.html#_camel_api[camel-api] | partial | Renamed Exchange.ACTIVE_SPAN to Exchange.OTEL_ACTIVE_SPAN. Renamed ExchangePropertyKey.ACTIVE_SPAN to ExchangePropertyKey.OTEL_ACTIVE_SPAN.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_9.html#_camel_management[camel-management] | N/A |
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_9.html#_using_route_templates[Route Templates] | N/A |
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_9.html#_camel_xml_io[camel-xml-io] | N/A |
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_9.html#_camel_jackson[camel-jackson] | N/A |
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_9.html#_camel_jms[camel-jms] | N/A |
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_9.html#_camel_opentelemetry[camel-opentelemetry] | N/A |
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_9.html#_camel_pubnub[camel-pubnub] | N/A |
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_9.html#_camel_smooks[camel-smooks] | N/A |
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_9.html#_camel_hashicorp_vault_properties_function[camel-hashicorp-vault properties function	] | partial | Literal expressions matching `(\{\{hashicorp:secret:[^/]+)/([^/]+}})` are migrated.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_9.html#_camel_aws_secrets_manager_properties_function[camel-aws-secrets-manager properties function] | partial | Literal expressions matching `(\{\{aws:[^/]+)/([^/]+}})` are migrated.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_9.html#_camel_aws_secrets_manager_properties_function[camel-google-secret-manager properties function] | partial | Literal expressions matching `(\{\{gcp:[^/]+)/([^/]+}})` are migrated.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_9.html#_camel_azure_key_vault_properties_function[camel-azure-key-vault properties function] | partial | Literal expressions matching `(\{\{azure:[^/]+)/([^/]+}})` are migrated.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_9.html#_camel_azure_key_vault_properties_function[camel-aws] | N/A |
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_9.html#_camel_test[camel-test] | N/A |
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_9.html#_camel_debezium[camel-debezium] | covered |
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_9.html#_deprecated_components[Deprecated components] | N/A |
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_9.html#_removed_deprecated_components[Removed deprecated components] | covered |
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_9.html#_removed_api[Removed API] | covered |
+
+

--- a/src/main/java/org/apache/camel/upgrade/camel41/CamelCoreRecipe.java
+++ b/src/main/java/org/apache/camel/upgrade/camel41/CamelCoreRecipe.java
@@ -56,8 +56,8 @@ public class CamelCoreRecipe extends Recipe {
 
         return RecipesUtil.newVisitor(new AbstractCamelJavaVisitor() {
             @Override
-            public J.Literal visitLiteral(J.Literal literal, ExecutionContext context) {
-                J.Literal l = super.visitLiteral(literal, context);
+            public J.Literal doVisitLiteral(J.Literal literal, ExecutionContext context) {
+                J.Literal l = super.doVisitLiteral(literal, context);
 
                 //is it possible to precondition that aws2 is present?
                 if (JavaType.Primitive.String.equals(l.getType())

--- a/src/main/java/org/apache/camel/upgrade/customRecipes/LiteralRegexpConverterRecipe.java
+++ b/src/main/java/org/apache/camel/upgrade/customRecipes/LiteralRegexpConverterRecipe.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.upgrade.customRecipes;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import org.apache.camel.upgrade.AbstractCamelJavaVisitor;
+import org.apache.camel.upgrade.RecipesUtil;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Option;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.TypeUtils;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.function.BiFunction;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Replaces literal matching pattern and replacing it with a replacement (regexp groups are supported)
+ */
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
+@AllArgsConstructor
+public class LiteralRegexpConverterRecipe extends Recipe {
+
+    @Option(displayName = "Literal regexp name",
+            description = "Regexp for matching a literal.")
+    public String regexp;
+
+    @Option(displayName = "Replacement to use",
+            description = "Replacement to use.")
+    public String replacement;
+
+    @Override
+    public String getDisplayName() {
+        return "Replaces a literal matching an expression";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Replaces literal, groups from regexp can be used as ${0}, ${1}, ...";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return RecipesUtil.newVisitor(new AbstractCamelJavaVisitor() {
+
+            @Override
+            protected J.Literal doVisitLiteral(J.Literal literal, ExecutionContext context) {
+                J.Literal l  =  super.doVisitLiteral(literal, context);
+
+                // Only handle String literals
+                if (TypeUtils.isString(literal.getType()) && literal.getValue() != null) {
+                    Matcher m = getPattern(regexp.trim()).matcher((String)literal.getValue());
+                    if(m.matches()) {
+                        //if no group one group is used
+                        String tmp = replacement;
+                        for (int i = 1; i <= 100; i++) {
+                            if(!tmp.contains("${" + i + "}")) {
+                                break;
+                            }
+                            String tmp2 = tmp.replaceAll("\\$\\{" + i + "}", m.group(i));
+                            //if there is no change, return value
+                            if(tmp.equals(tmp2)) {
+                                break;
+                            }
+                            tmp = tmp2;
+                        }
+                        return RecipesUtil.createStringLiteral(tmp);
+                    }
+                }
+
+                return l;
+            }
+        });
+    }
+}

--- a/src/main/resources/META-INF/rewrite/4.9.yaml
+++ b/src/main/resources/META-INF/rewrite/4.9.yaml
@@ -1,0 +1,268 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#####
+# Rules coming from https://camel.apache.org/manual/camel-4x-upgrade-guide-4_8.html#_upgrading_camel_4_7_to_4_8
+# None of the migrations can be covered by the automation migrations.
+#####
+
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.apache.camel.upgrade.camel49.CamelMigrationRecipe
+displayName: Migrates `camel 4.8` application to `camel 4.9`
+description: Migrates `camel 4.8` application to `camel 4.9`.
+recipeList:
+  - org.apache.camel.upgrade.camel49.renamedAPIs
+  - org.apache.camel.upgrade.camel49.HashicorpSecretRecipe
+  - org.apache.camel.upgrade.camel49.GcpSecretRecipe
+  - org.apache.camel.upgrade.camel49.AwsSecretRecipe
+  - org.apache.camel.upgrade.camel49.AzureSecretRecipe
+  - org.apache.camel.upgrade.camel49.DebeziumChangeTypes
+  - org.apache.camel.upgrade.camel49.removedDependencies
+---
+#https://camel.apache.org/manual/camel-4x-upgrade-guide-4_9.html#_camel_api
+type: specs.openrewrite.org/v1beta/recipe
+name: org.apache.camel.upgrade.camel49.renamedAPIs
+displayName: Renamed classes for API
+description: Renamed classes for API.
+recipeList:
+  - org.openrewrite.java.ReplaceConstantWithAnotherConstant:
+      existingFullyQualifiedConstantName: org.apache.camel.Exchange.ACTIVE_SPAN
+      fullyQualifiedConstantName: org.apache.camel.Exchange.OTEL_ACTIVE_SPAN
+  - org.openrewrite.java.ReplaceConstantWithAnotherConstant:
+      existingFullyQualifiedConstantName: org.apache.camel.ExchangePropertyKey.ACTIVE_SPAN
+      fullyQualifiedConstantName: org.apache.camel.ExchangePropertyKey.OTEL_ACTIVE_SPAN
+---
+#thttps://camel.apache.org/manual/camel-4x-upgrade-guide-4_9.html#_camel_hashicorp_vault_properties_function
+type: specs.openrewrite.org/v1beta/recipe
+name: org.apache.camel.upgrade.camel49.HashicorpSecretRecipe
+displayName: The syntax for retrieving a single field of a secret has been changed
+description: The syntax for retrieving a single field of a secret has been changed..
+recipeList:
+  - org.apache.camel.upgrade.customRecipes.LiteralRegexpConverterRecipe:
+      regexp: "(\\{\\{hashicorp:secret:[^/]+)/([^/]+}})"
+      replacement:  "${1}#${2}"
+---
+#https://camel.apache.org/manual/camel-4x-upgrade-guide-4_9.html#_camel_google_secret_manager_properties_function
+type: specs.openrewrite.org/v1beta/recipe
+name: org.apache.camel.upgrade.camel49.GcpSecretRecipe
+displayName: The syntax for retrieving a single field of a secret has been changed
+description: The syntax for retrieving a single field of a secret has been changed..
+recipeList:
+  - org.apache.camel.upgrade.customRecipes.LiteralRegexpConverterRecipe:
+      regexp: "(\\{\\{gcp:[^/]+)/([^/]+}})"
+      replacement:  "${1}#${2}"
+---
+#https://camel.apache.org/manual/camel-4x-upgrade-guide-4_9.html#_camel_aws_secrets_manager_properties_function
+type: specs.openrewrite.org/v1beta/recipe
+name: org.apache.camel.upgrade.camel49.AwsSecretRecipe
+displayName: The syntax for retrieving a single field of a secret has been changed
+description: The syntax for retrieving a single field of a secret has been changed..
+recipeList:
+  - org.apache.camel.upgrade.customRecipes.LiteralRegexpConverterRecipe:
+      regexp: "(\\{\\{aws:[^/]+)/([^/]+}})"
+      replacement:  "${1}#${2}"
+---
+#https://camel.apache.org/manual/camel-4x-upgrade-guide-4_9.html#_camel_azure_key_vault_properties_function
+type: specs.openrewrite.org/v1beta/recipe
+name: org.apache.camel.upgrade.camel49.AzureSecretRecipe
+displayName: The syntax for retrieving a single field of a secret has been changed
+description: The syntax for retrieving a single field of a secret has been changed..
+recipeList:
+  - org.apache.camel.upgrade.customRecipes.LiteralRegexpConverterRecipe:
+      regexp: "(\\{\\{azure:[^/]+)/([^/]+}})"
+      replacement:  "${1}#${2}"
+---
+#https://camel.apache.org/manual/camel-4x-upgrade-guide-4_9.html#_camel_debezium
+type: specs.openrewrite.org/v1beta/recipe
+name: org.apache.camel.upgrade.camel49.DebeziumChangeTypes
+displayName: Each camel-debezium module has its own subpackage corresponding to the database type
+description: each camel-debezium module has its own subpackage corresponding to the database type. So for example, all the classes of the module camel-debezium-postgres have been moved to a dedicated package which is org.apache.camel.component.debezium.postgres instead of having everything under the root package org.apache.camel.component.debezium.
+recipeList:
+#  db2
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.debezium.configuration.Db2ConnectorEmbeddedDebeziumConfiguration
+      newFullyQualifiedTypeName: org.apache.camel.component.debezium.db2.configuration.Db2ConnectorEmbeddedDebeziumConfiguration
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.debezium.DebeziumDb2ComponentConfigurer
+      newFullyQualifiedTypeName: org.apache.camel.component.debezium.db2.DebeziumDb2ComponentConfigurer
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.debezium.DebeziumDb2EndpointConfigurer
+      newFullyQualifiedTypeName: org.apache.camel.component.debezium.db2.DebeziumDb2EndpointConfigurer
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.debezium.DebeziumDb2EndpointUriFactory
+      newFullyQualifiedTypeName: org.apache.camel.component.debezium.db2.DebeziumDb2EndpointUriFactory
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.debezium.DebeziumDb2Component
+      newFullyQualifiedTypeName: org.apache.camel.component.debezium.db2.DebeziumDb2Component
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.debezium.DebeziumDb2ComponentConfigurer
+      newFullyQualifiedTypeName: org.apache.camel.component.debezium.db2.DebeziumDb2ComponentConfigurer
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.debezium.DebeziumDb2EndpointConfigurer
+      newFullyQualifiedTypeName: org.apache.camel.component.debezium.db2.DebeziumDb2EndpointConfigurer
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.debezium.DebeziumDb2Endpoint
+      newFullyQualifiedTypeName: org.apache.camel.component.debezium.db2.DebeziumDb2Endpoint
+#  mongoDb
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.debezium.configuration.MongodbConnectorEmbeddedDebeziumConfiguration
+      newFullyQualifiedTypeName: org.apache.camel.component.debezium.mongodb.configuration.MongodbConnectorEmbeddedDebeziumConfiguration
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.debezium.DebeziumMongodbComponentConfigurer
+      newFullyQualifiedTypeName: org.apache.camel.component.debezium.mongodb.DebeziumMongodbComponentConfigurer
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.debezium.DebeziumMongodbEndpointConfigurer
+      newFullyQualifiedTypeName: org.apache.camel.component.debezium.mongodb.DebeziumMongodbEndpointConfigurer
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.debezium.DebeziumMongodbEndpointUriFactory
+      newFullyQualifiedTypeName: org.apache.camel.component.debezium.mongodb.DebeziumMongodbEndpointUriFactory
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.debezium.DebeziumMongodbComponent
+      newFullyQualifiedTypeName: org.apache.camel.component.debezium.mongodb.DebeziumMongodbComponent
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.debezium.DebeziumMongodbComponentConfigurer
+      newFullyQualifiedTypeName: org.apache.camel.component.debezium.mongodb.DebeziumMongodbComponentConfigurer
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.debezium.DebeziumMongodbEndpointConfigurer
+      newFullyQualifiedTypeName: org.apache.camel.component.debezium.mongodb.DebeziumMongodbEndpointConfigurer
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.debezium.DebeziumMongodbEndpoint
+      newFullyQualifiedTypeName: org.apache.camel.component.debezium.mongodb.DebeziumMongodbEndpoint
+#  mysql
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.debezium.configuration.MySqlConnectorEmbeddedDebeziumConfiguration
+      newFullyQualifiedTypeName: org.apache.camel.component.debezium.mysql.configuration.MySqlConnectorEmbeddedDebeziumConfiguration
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.debezium.DebeziumMySqlComponentConfigurer
+      newFullyQualifiedTypeName: org.apache.camel.component.debezium.mysql.DebeziumMySqlComponentConfigurer
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.debezium.DebeziumMySqlEndpointConfigurer
+      newFullyQualifiedTypeName: org.apache.camel.component.debezium.mysql.DebeziumMySqlEndpointConfigurer
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.debezium.DebeziumMySqlEndpointUriFactory
+      newFullyQualifiedTypeName: org.apache.camel.component.debezium.mysql.DebeziumMySqlEndpointUriFactory
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.debezium.DebeziumMySqlComponent
+      newFullyQualifiedTypeName: org.apache.camel.component.debezium.mysql.DebeziumMySqlComponent
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.debezium.DebeziumMySqlComponentConfigurer
+      newFullyQualifiedTypeName: org.apache.camel.component.debezium.mysql.DebeziumMySqlComponentConfigurer
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.debezium.DebeziumMySqlEndpointConfigurer
+      newFullyQualifiedTypeName: org.apache.camel.component.debezium.mysql.DebeziumMySqlEndpointConfigurer
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.debezium.DebeziumMySqlEndpoint
+      newFullyQualifiedTypeName: org.apache.camel.component.debezium.mysql.DebeziumMySqlEndpoint
+#  oracle
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.debezium.configuration.OracleConnectorEmbeddedDebeziumConfiguration
+      newFullyQualifiedTypeName: org.apache.camel.component.debezium.oracle.configuration.OracleConnectorEmbeddedDebeziumConfiguration
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.debezium.DebeziumOracleComponentConfigurer
+      newFullyQualifiedTypeName: org.apache.camel.component.debezium.oracle.DebeziumOracleComponentConfigurer
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.debezium.DebeziumOracleEndpointConfigurer
+      newFullyQualifiedTypeName: org.apache.camel.component.debezium.oracle.DebeziumOracleEndpointConfigurer
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.debezium.DebeziumOracleEndpointUriFactory
+      newFullyQualifiedTypeName: org.apache.camel.component.debezium.oracle.DebeziumOracleEndpointUriFactory
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.debezium.DebeziumOracleComponent
+      newFullyQualifiedTypeName: org.apache.camel.component.debezium.oracle.DebeziumOracleComponent
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.debezium.DebeziumOracleComponentConfigurer
+      newFullyQualifiedTypeName: org.apache.camel.component.debezium.oracle.DebeziumOracleComponentConfigurer
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.debezium.DebeziumOracleEndpointConfigurer
+      newFullyQualifiedTypeName: org.apache.camel.component.debezium.oracle.DebeziumOracleEndpointConfigurer
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.debezium.DebeziumOracleEndpoint
+      newFullyQualifiedTypeName: org.apache.camel.component.debezium.oracle.DebeziumOracleEndpoint
+#  postgres
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.debezium.configuration.PostgresConnectorEmbeddedDebeziumConfiguration
+      newFullyQualifiedTypeName: org.apache.camel.component.debezium.postgres.configuration.PostgresConnectorEmbeddedDebeziumConfiguration
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.debezium.DebeziumPostgresComponentConfigurer
+      newFullyQualifiedTypeName: org.apache.camel.component.debezium.postgres.DebeziumPostgresComponentConfigurer
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.debezium.DebeziumPostgresEndpointConfigurer
+      newFullyQualifiedTypeName: org.apache.camel.component.debezium.postgres.DebeziumPostgresEndpointConfigurer
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.debezium.DebeziumPostgresEndpointUriFactory
+      newFullyQualifiedTypeName: org.apache.camel.component.debezium.postgres.DebeziumPostgresEndpointUriFactory
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.debezium.DebeziumPostgresComponent
+      newFullyQualifiedTypeName: org.apache.camel.component.debezium.postgres.DebeziumPostgresComponent
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.debezium.DebeziumPostgresComponentConfigurer
+      newFullyQualifiedTypeName: org.apache.camel.component.debezium.postgres.DebeziumPostgresComponentConfigurer
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.debezium.DebeziumPostgresEndpointConfigurer
+      newFullyQualifiedTypeName: org.apache.camel.component.debezium.postgres.DebeziumPostgresEndpointConfigurer
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.debezium.DebeziumPostgresEndpoint
+      newFullyQualifiedTypeName: org.apache.camel.component.debezium.postgres.DebeziumPostgresEndpoint
+#  sqlserver
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.debezium.configuration.SqlserverConnectorEmbeddedDebeziumConfiguration
+      newFullyQualifiedTypeName: org.apache.camel.component.debezium.sqlserver.configuration.SqlserverConnectorEmbeddedDebeziumConfiguration
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.debezium.DebeziumSqlserverComponentConfigurer
+      newFullyQualifiedTypeName: org.apache.camel.component.debezium.sqlserver.DebeziumSqlserverComponentConfigurer
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.debezium.DebeziumSqlserverEndpointConfigurer
+      newFullyQualifiedTypeName: org.apache.camel.component.debezium.sqlserver.DebeziumSqlserverEndpointConfigurer
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.debezium.DebeziumSqlserverEndpointUriFactory
+      newFullyQualifiedTypeName: org.apache.camel.component.debezium.sqlserver.DebeziumSqlserverEndpointUriFactory
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.debezium.DebeziumSqlserverComponent
+      newFullyQualifiedTypeName: org.apache.camel.component.debezium.sqlserver.DebeziumSqlserverComponent
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.debezium.DebeziumSqlserverComponentConfigurer
+      newFullyQualifiedTypeName: org.apache.camel.component.debezium.sqlserver.DebeziumSqlserverComponentConfigurer
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.debezium.DebeziumSqlserverEndpointConfigurer
+      newFullyQualifiedTypeName: org.apache.camel.component.debezium.sqlserver.DebeziumSqlserverEndpointConfigurer
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.debezium.DebeziumSqlserverEndpoint
+      newFullyQualifiedTypeName: org.apache.camel.component.debezium.sqlserver.DebeziumSqlserverEndpoint
+---
+#https://camel.apache.org/manual/camel-4x-upgrade-guide-4_9.html#_removed_deprecated_components
+#https://camel.apache.org/manual/camel-4x-upgrade-guide-4_9.html#_removed_api
+type: specs.openrewrite.org/v1beta/recipe
+name: org.apache.camel.upgrade.camel49.removedDependencies
+displayName: Removed deprecated components
+description: Removed deprecated components (camel-groovy-dsl, camel-js-dsl, camel-jsh-dsl, camel-kotlin-api, camel-kotlin-dsl).
+recipeList:
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: org.apache.camel
+      artifactId: camel-groovy-dsl
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: org.apache.camel
+      artifactId: camel-js-dsl
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: org.apache.camel
+      artifactId: camel-jsh-dsl
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: org.apache.camel
+      artifactId: camel-kotlin-api
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: org.apache.camel
+      artifactId: camel-kotlin-dsl

--- a/src/test/java/org/apache/camel/upgrade/CamelTestUtil.java
+++ b/src/test/java/org/apache/camel/upgrade/CamelTestUtil.java
@@ -42,7 +42,9 @@ public class CamelTestUtil {
         v4_4(4, 4, 2),
         v4_5(4, 5, 0),
         v4_6(4, 6, 0),
-        v4_7(4, 7, 0);
+        v4_7(4, 7, 0),
+        v4_8(4, 8, 0),
+        v4_9(4, 9, 0);
 
         private int major;
         private int minor;

--- a/src/test/java/org/apache/camel/upgrade/CamelUpdate49Test.java
+++ b/src/test/java/org/apache/camel/upgrade/CamelUpdate49Test.java
@@ -1,0 +1,412 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.upgrade;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
+import org.openrewrite.yaml.Assertions;
+
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.maven.Assertions.pomXml;
+import static org.openrewrite.xml.Assertions.xml;
+
+public class CamelUpdate49Test implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        CamelTestUtil.recipe(spec, CamelTestUtil.CamelVersion.v4_9)
+                .parser(CamelTestUtil.parserFromClasspath(CamelTestUtil.CamelVersion.v4_8,
+                        "camel-api", "camel-core-model", "camel-debezium-db2", "camel-debezium-mysql", "camel-debezium-oracle", "camel-debezium-mongodb", "camel-debezium-postgres", "camel-debezium-sqlserver"))
+                .typeValidationOptions(TypeValidation.none());
+    }
+
+    /**
+     * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_9.html#_camel_api">camel-api</a>
+     */
+    @Test
+    public void testApiChanges() {
+        //language=java
+        rewriteRun(java(
+                """
+                             import org.apache.camel.Exchange;
+                             import org.apache.camel.ExchangePropertyKey;
+                             
+                             public class ApisTest {
+                                 public void test() {
+                                     var s1 = Exchange.ACTIVE_SPAN;
+                                     var s2 = ExchangePropertyKey.ACTIVE_SPAN.name();
+                                     System.out.println(s1 + ":" + s2);
+                                 }
+                             }
+                        """,
+                """
+                             import org.apache.camel.Exchange;
+                             import org.apache.camel.ExchangePropertyKey;
+                            
+                             public class ApisTest {
+                                 public void test() {
+                                     var s1 = Exchange.OTEL_ACTIVE_SPAN;
+                                     var s2 = ExchangePropertyKey.OTEL_ACTIVE_SPAN.name();
+                                     System.out.println(s1 + ":" + s2);
+                                 }
+                             }
+                        """));
+    }
+
+    /**
+     * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_9.html#_camel_hashicorp_vault_properties_function">camel-hashicorp-vault properties function</a>
+     * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_9.html#_camel_aws_secrets_manager_properties_function">camel-aws-secrets-manager properties function</a>
+     * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_9.html#_camel_google_secret_manager_properties_function">camel-google-secret-manager properties function</a>
+     * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_9.html#_camel_azure_key_vault_properties_function">camel-azure-key-vault properties function</a>
+     */
+    @Test
+    public void testSecretFieldSyntax() {
+        //language=java
+        rewriteRun(java(
+                """
+                        import org.apache.camel.builder.RouteBuilder;
+    
+                        public class SecretFieldRoute extends RouteBuilder {
+    
+                            @Override
+                            public void configure() {
+                                from("direct:a")
+                                    .inOut("{{hashicorp:secret:db/user}}")
+                                    .to("log:result_hashicorp:secret");
+                                from("direct:a")
+                                    .inOut("{{aws:436etrt/Sheldon}}")
+                                    .to("log:result_aws");
+                                from("direct:a")
+                                    .inOut("{{gcp:3ee4ff/Leonard}}")
+                                    .to("log:result_aws");
+                                from("direct:a")
+                                    .inOut("{{azure:de43e56e6d6/Vilma}}")
+                                    .to("log:result_azure");
+                                from("direct:a")
+                                    .inOut("{{azure:something/wrong/JoeD}}")
+                                    .to("log:result_azure");
+                                from("direct:a")
+                                    .inOut("{{wrong:de43e56e6d6/JoeD}}")
+                                    .to("log:result_azure");
+                            }
+                        }
+                        """,
+                """
+                           import org.apache.camel.builder.RouteBuilder;
+       
+                           public class SecretFieldRoute extends RouteBuilder {
+       
+                               @Override
+                               public void configure() {
+                                   from("direct:a")
+                                       .inOut("{{hashicorp:secret:db#user}}")
+                                       .to("log:result_hashicorp:secret");
+                                   from("direct:a")
+                                       .inOut("{{aws:436etrt#Sheldon}}")
+                                       .to("log:result_aws");
+                                   from("direct:a")
+                                       .inOut("{{gcp:3ee4ff#Leonard}}")
+                                       .to("log:result_aws");
+                                   from("direct:a")
+                                       .inOut("{{azure:de43e56e6d6#Vilma}}")
+                                       .to("log:result_azure");
+                                   from("direct:a")
+                                       .inOut("{{azure:something/wrong/JoeD}}")
+                                       .to("log:result_azure");
+                                   from("direct:a")
+                                       .inOut("{{wrong:de43e56e6d6/JoeD}}")
+                                       .to("log:result_azure");
+                               }
+                           }
+                       """));
+    }
+    /**
+     * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_9.html#_camel_debezium">camel-debezium</a>
+     */
+    @Test
+    public void testDebezium() {
+        //language=java
+        rewriteRun(java(
+                """
+                        import org.apache.camel.component.debezium.configuration.Db2ConnectorEmbeddedDebeziumConfiguration;
+                        import org.apache.camel.component.debezium.DebeziumDb2ComponentConfigurer;
+                        import org.apache.camel.component.debezium.DebeziumDb2EndpointConfigurer;
+                        import org.apache.camel.component.debezium.DebeziumDb2EndpointUriFactory;
+                        import org.apache.camel.component.debezium.DebeziumDb2Component;
+                        import org.apache.camel.component.debezium.DebeziumDb2ComponentConfigurer;
+                        import org.apache.camel.component.debezium.DebeziumDb2EndpointConfigurer;
+                        import org.apache.camel.component.debezium.DebeziumDb2Endpoint;
+                        import org.apache.camel.component.debezium.configuration.MongodbConnectorEmbeddedDebeziumConfiguration;
+                        import org.apache.camel.component.debezium.DebeziumMongodbComponentConfigurer;
+                        import org.apache.camel.component.debezium.DebeziumMongodbEndpointConfigurer;
+                        import org.apache.camel.component.debezium.DebeziumMongodbEndpointUriFactory;
+                        import org.apache.camel.component.debezium.DebeziumMongodbComponent;
+                        import org.apache.camel.component.debezium.DebeziumMongodbComponentConfigurer;
+                        import org.apache.camel.component.debezium.DebeziumMongodbEndpointConfigurer;
+                        import org.apache.camel.component.debezium.DebeziumMongodbEndpoint;
+                        import org.apache.camel.component.debezium.configuration.MySqlConnectorEmbeddedDebeziumConfiguration;
+                        import org.apache.camel.component.debezium.DebeziumMySqlComponentConfigurer;
+                        import org.apache.camel.component.debezium.DebeziumMySqlEndpointConfigurer;
+                        import org.apache.camel.component.debezium.DebeziumMySqlEndpointUriFactory;
+                        import org.apache.camel.component.debezium.DebeziumMySqlComponent;
+                        import org.apache.camel.component.debezium.DebeziumMySqlComponentConfigurer;
+                        import org.apache.camel.component.debezium.DebeziumMySqlEndpointConfigurer;
+                        import org.apache.camel.component.debezium.DebeziumMySqlEndpoint;
+                        import org.apache.camel.component.debezium.configuration.OracleConnectorEmbeddedDebeziumConfiguration;
+                        import org.apache.camel.component.debezium.DebeziumOracleComponentConfigurer;
+                        import org.apache.camel.component.debezium.DebeziumOracleEndpointConfigurer;
+                        import org.apache.camel.component.debezium.DebeziumOracleEndpointUriFactory;
+                        import org.apache.camel.component.debezium.DebeziumOracleComponent;
+                        import org.apache.camel.component.debezium.DebeziumOracleComponentConfigurer;
+                        import org.apache.camel.component.debezium.DebeziumOracleEndpointConfigurer;
+                        import org.apache.camel.component.debezium.DebeziumOracleEndpoint;
+                        import org.apache.camel.component.debezium.configuration.PostgresConnectorEmbeddedDebeziumConfiguration;
+                        import org.apache.camel.component.debezium.DebeziumPostgresComponentConfigurer;
+                        import org.apache.camel.component.debezium.DebeziumPostgresEndpointConfigurer;
+                        import org.apache.camel.component.debezium.DebeziumPostgresEndpointUriFactory;
+                        import org.apache.camel.component.debezium.DebeziumPostgresComponent;
+                        import org.apache.camel.component.debezium.DebeziumPostgresComponentConfigurer;
+                        import org.apache.camel.component.debezium.DebeziumPostgresEndpointConfigurer;
+                        import org.apache.camel.component.debezium.DebeziumPostgresEndpoint;
+                        import org.apache.camel.component.debezium.configuration.SqlserverConnectorEmbeddedDebeziumConfiguration;
+                        import org.apache.camel.component.debezium.DebeziumSqlserverComponentConfigurer;
+                        import org.apache.camel.component.debezium.DebeziumSqlserverEndpointConfigurer;
+                        import org.apache.camel.component.debezium.DebeziumSqlserverEndpointUriFactory;
+                        import org.apache.camel.component.debezium.DebeziumSqlserverComponent;
+                        import org.apache.camel.component.debezium.DebeziumSqlserverComponentConfigurer;
+                        import org.apache.camel.component.debezium.DebeziumSqlserverEndpointConfigurer;
+                        import org.apache.camel.component.debezium.DebeziumSqlserverEndpoint;
+                        
+                        public class DebeziumTest {
+    
+                            public void method() {
+                                //db2
+                                Db2ConnectorEmbeddedDebeziumConfiguration conf = null;
+                                DebeziumDb2ComponentConfigurer configurer = null;
+                                DebeziumDb2EndpointConfigurer endpointConfigurer = null;
+                                DebeziumDb2EndpointUriFactory uriFactory = null;
+                                DebeziumDb2Component component = null;
+                                DebeziumDb2ComponentConfigurer componentConfigurer = null;
+                                DebeziumDb2EndpointConfigurer endpointConfigurer = null;
+                                DebeziumDb2Endpoint endpoint = null;
+                                //mongodb
+                                MongodbConnectorEmbeddedDebeziumConfiguration conf = null;
+                                DebeziumMongodbComponentConfigurer configurer = null;
+                                DebeziumMongodbEndpointConfigurer endpointConfigurer = null;
+                                DebeziumMongodbEndpointUriFactory uriFactory = null;
+                                DebeziumMongodbComponent component = null;
+                                DebeziumMongodbComponentConfigurer componentConfigurer = null;
+                                DebeziumMongodbEndpointConfigurer endpointConfigurer = null;
+                                DebeziumMongodbEndpoint endpoint = null;
+                                //mysql
+                                MySqlConnectorEmbeddedDebeziumConfiguration conf = null;
+                                DebeziumMySqlComponentConfigurer configurer = null;
+                                DebeziumMySqlEndpointConfigurer endpointConfigurer = null;
+                                DebeziumMySqlEndpointUriFactory uriFactory = null;
+                                DebeziumMySqlComponent component = null;
+                                DebeziumMySqlComponentConfigurer componentConfigurer = null;
+                                DebeziumMySqlEndpointConfigurer endpointConfigurer = null;
+                                DebeziumMySqlEndpoint endpoint = null;
+                                //oracle
+                                OracleConnectorEmbeddedDebeziumConfiguration conf = null;
+                                DebeziumOracleComponentConfigurer configurer = null;
+                                DebeziumOracleEndpointConfigurer endpointConfigurer = null;
+                                DebeziumOracleEndpointUriFactory uriFactory = null;
+                                DebeziumOracleComponent component = null;
+                                DebeziumOracleComponentConfigurer componentConfigurer = null;
+                                DebeziumOracleEndpointConfigurer endpointConfigurer = null;
+                                DebeziumOracleEndpoint endpoint = null;
+                                //postgres
+                                PostgresConnectorEmbeddedDebeziumConfiguration conf = null;
+                                DebeziumPostgresComponentConfigurer configurer = null;
+                                DebeziumPostgresEndpointConfigurer endpointConfigurer = null;
+                                DebeziumPostgresEndpointUriFactory uriFactory = null;
+                                DebeziumPostgresComponent component = null;
+                                DebeziumPostgresComponentConfigurer componentConfigurer = null;
+                                DebeziumPostgresEndpointConfigurer endpointConfigurer = null;
+                                DebeziumPostgresEndpoint endpoint = null;
+                                //sqlserver
+                                SqlserverConnectorEmbeddedDebeziumConfiguration conf = null;
+                                DebeziumSqlserverComponentConfigurer configurer = null;
+                                DebeziumSqlserverEndpointConfigurer endpointConfigurer = null;
+                                DebeziumSqlserverEndpointUriFactory uriFactory = null;
+                                DebeziumSqlserverComponent component = null;
+                                DebeziumSqlserverComponentConfigurer componentConfigurer = null;
+                                DebeziumSqlserverEndpointConfigurer endpointConfigurer = null;
+                                DebeziumSqlserverEndpoint endpoint = null;
+                            }
+                        }
+                        """,
+                """
+                        import org.apache.camel.component.debezium.configuration.MongodbConnectorEmbeddedDebeziumConfiguration;
+                        import org.apache.camel.component.debezium.configuration.SqlserverConnectorEmbeddedDebeziumConfiguration;
+                        import org.apache.camel.component.debezium.db2.*;
+                        import org.apache.camel.component.debezium.db2.configuration.Db2ConnectorEmbeddedDebeziumConfiguration;
+                        import org.apache.camel.component.debezium.mongodb.*;
+                        import org.apache.camel.component.debezium.mysql.*;
+                        import org.apache.camel.component.debezium.mysql.configuration.MySqlConnectorEmbeddedDebeziumConfiguration;
+                        import org.apache.camel.component.debezium.oracle.*;
+                        import org.apache.camel.component.debezium.oracle.configuration.OracleConnectorEmbeddedDebeziumConfiguration;
+                        import org.apache.camel.component.debezium.postgres.*;
+                        import org.apache.camel.component.debezium.postgres.configuration.PostgresConnectorEmbeddedDebeziumConfiguration;
+                        import org.apache.camel.component.debezium.sqlserver.*;
+                        
+                        public class DebeziumTest {
+                        
+                            public void method() {
+                                //db2
+                                Db2ConnectorEmbeddedDebeziumConfiguration conf = null;
+                                DebeziumDb2ComponentConfigurer configurer = null;
+                                DebeziumDb2EndpointConfigurer endpointConfigurer = null;
+                                DebeziumDb2EndpointUriFactory uriFactory = null;
+                                DebeziumDb2Component component = null;
+                                DebeziumDb2ComponentConfigurer componentConfigurer = null;
+                                DebeziumDb2EndpointConfigurer endpointConfigurer = null;
+                                DebeziumDb2Endpoint endpoint = null;
+                                //mongodb
+                                MongodbConnectorEmbeddedDebeziumConfiguration conf = null;
+                                DebeziumMongodbComponentConfigurer configurer = null;
+                                DebeziumMongodbEndpointConfigurer endpointConfigurer = null;
+                                DebeziumMongodbEndpointUriFactory uriFactory = null;
+                                DebeziumMongodbComponent component = null;
+                                DebeziumMongodbComponentConfigurer componentConfigurer = null;
+                                DebeziumMongodbEndpointConfigurer endpointConfigurer = null;
+                                DebeziumMongodbEndpoint endpoint = null;
+                                //mysql
+                                MySqlConnectorEmbeddedDebeziumConfiguration conf = null;
+                                DebeziumMySqlComponentConfigurer configurer = null;
+                                DebeziumMySqlEndpointConfigurer endpointConfigurer = null;
+                                DebeziumMySqlEndpointUriFactory uriFactory = null;
+                                DebeziumMySqlComponent component = null;
+                                DebeziumMySqlComponentConfigurer componentConfigurer = null;
+                                DebeziumMySqlEndpointConfigurer endpointConfigurer = null;
+                                DebeziumMySqlEndpoint endpoint = null;
+                                //oracle
+                                OracleConnectorEmbeddedDebeziumConfiguration conf = null;
+                                DebeziumOracleComponentConfigurer configurer = null;
+                                DebeziumOracleEndpointConfigurer endpointConfigurer = null;
+                                DebeziumOracleEndpointUriFactory uriFactory = null;
+                                DebeziumOracleComponent component = null;
+                                DebeziumOracleComponentConfigurer componentConfigurer = null;
+                                DebeziumOracleEndpointConfigurer endpointConfigurer = null;
+                                DebeziumOracleEndpoint endpoint = null;
+                                //postgres
+                                PostgresConnectorEmbeddedDebeziumConfiguration conf = null;
+                                DebeziumPostgresComponentConfigurer configurer = null;
+                                DebeziumPostgresEndpointConfigurer endpointConfigurer = null;
+                                DebeziumPostgresEndpointUriFactory uriFactory = null;
+                                DebeziumPostgresComponent component = null;
+                                DebeziumPostgresComponentConfigurer componentConfigurer = null;
+                                DebeziumPostgresEndpointConfigurer endpointConfigurer = null;
+                                DebeziumPostgresEndpoint endpoint = null;
+                                //sqlserver
+                                SqlserverConnectorEmbeddedDebeziumConfiguration conf = null;
+                                DebeziumSqlserverComponentConfigurer configurer = null;
+                                DebeziumSqlserverEndpointConfigurer endpointConfigurer = null;
+                                DebeziumSqlserverEndpointUriFactory uriFactory = null;
+                                DebeziumSqlserverComponent component = null;
+                                DebeziumSqlserverComponentConfigurer componentConfigurer = null;
+                                DebeziumSqlserverEndpointConfigurer endpointConfigurer = null;
+                                DebeziumSqlserverEndpoint endpoint = null;
+                            }
+                        }
+                      """));
+    }
+
+    /**
+     * TODO update link
+     * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_9.html#_removed_deprecated_components">Removed deprecated components</a>
+     * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_9.html#_removed_api">Removed API</a>
+     */
+    @Test
+    public void testRemovedDependencies() {
+        //language=xml
+        rewriteRun(pomXml(
+                """
+                        <project>
+                           <modelVersion>4.0.0</modelVersion>
+
+                           <artifactId>test</artifactId>
+                           <groupId>org.apache.camel.test</groupId>
+                           <version>1.0.0</version>
+
+                           <properties>
+                               <camel.version>4.8.0</camel.version>
+                           </properties>
+
+                           <dependencies>
+                               <dependency>
+                                   <groupId>org.apache.camel</groupId>
+                                   <artifactId>camel-api</artifactId>
+                                   <version>${camel.version}</version>
+                               </dependency>
+                               <dependency>
+                                   <groupId>org.apache.camel</groupId>
+                                   <artifactId>camel-groovy-dsl</artifactId>
+                                   <version>${camel.version}</version>
+                               </dependency>
+                               <dependency>
+                                   <groupId>org.apache.camel</groupId>
+                                   <artifactId>camel-js-dsl</artifactId>
+                                   <version>${camel.version}</version>
+                               </dependency>
+                               <dependency>
+                                   <groupId>org.apache.camel</groupId>
+                                   <artifactId>camel-jsh-dsl</artifactId>
+                                   <version>${camel.version}</version>
+                               </dependency>
+                               <dependency>
+                                   <groupId>org.apache.camel</groupId>
+                                   <artifactId>camel-kotlin-api</artifactId>
+                                   <version>${camel.version}</version>
+                               </dependency>
+                               <dependency>
+                                   <groupId>org.apache.camel</groupId>
+                                   <artifactId>camel-kotlin-dsl</artifactId>
+                                   <version>${camel.version}</version>
+                               </dependency>
+                            </dependencies>
+
+                        </project>
+                        """,
+                """
+                        <project>
+                           <modelVersion>4.0.0</modelVersion>
+
+                           <artifactId>test</artifactId>
+                           <groupId>org.apache.camel.test</groupId>
+                           <version>1.0.0</version>
+
+                           <properties>
+                               <camel.version>4.8.0</camel.version>
+                           </properties>
+
+                           <dependencies>
+                               <dependency>
+                                   <groupId>org.apache.camel</groupId>
+                                   <artifactId>camel-api</artifactId>
+                                   <version>${camel.version}</version>
+                               </dependency>
+                            </dependencies>
+
+                        </project>
+                        """));
+    }
+
+}


### PR DESCRIPTION
fixes https://issues.apache.org/jira/browse/CAMEL-21483

- Recipes for migration from Camel 4.8 to Camel 4.9
- release_notes.adoc describing, which parts of the migration guide could be covered by the recipes.
