### PR TITLE
Add a camel-spring-boot-version separate from camel-version to deal with the camel-spring-boot versions in the rewrite recipes

### DIFF
--- a/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/4.10.yaml
+++ b/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/4.10.yaml
@@ -32,7 +32,7 @@ recipeList:
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: '*camel*'
       artifactId: 'camel-spring-boot-bom'
-      newVersion: @project.version@
+      newVersion: @camel-spring-boot-version@
   - org.openrewrite.maven.RemoveDependency:
         groupId: org.apache.camel.springboot
         artifactId: camel-k-starter

--- a/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/4.9.yaml
+++ b/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/4.9.yaml
@@ -30,4 +30,4 @@ recipeList:
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: '*camel*'
       artifactId: 'camel-spring-boot-bom'
-      newVersion: @camel-version@
+      newVersion: @camel-spring-boot-version@

--- a/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/latest.yaml
+++ b/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/latest.yaml
@@ -34,19 +34,19 @@ recipeList:
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: '*camel*'
       artifactId: 'camel-spring-boot-bom'
-      newVersion: @camel-version@
+      newVersion: @camel-spring-boot-version@
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: 'org.apache.camel.springboot'
       artifactId: 'spring-boot'
-      newVersion: @camel-version@
+      newVersion: @camel-spring-boot-version@
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: 'org.apache.camel.springboot'
       artifactId: 'camel-spring-boot-dependencies'
-      newVersion: @camel-version@
+      newVersion: @camel-spring-boot-version@
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: 'org.apache.camel.springboot'
       artifactId: 'camel-spring-boot-dependencies'
-      newVersion: @camel-version@
+      newVersion: @camel-spring-boot-version@
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: org.springframework.boot
       artifactId: "*"

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,7 @@
         <camel4.9-version>4.9.0</camel4.9-version>
 
         <camel-version>${project.version}</camel-version>
+        <camel-spring-boot-version>${project.version}</camel-spring-boot-version>
 
         <rewrite-recipe-bom.version>3.0.2</rewrite-recipe-bom.version>
 


### PR DESCRIPTION
The camel-spring-boot rewrite recipes use a camel-version and a project-version for rewriting - add a camel-spring-boot-version specific to the camel-spring-boot rewrite recipes.