### PR TITLE
fixes #28: upgrade to 4.11

### DIFF
--- a/camel-upgrade-recipes/pom.xml
+++ b/camel-upgrade-recipes/pom.xml
@@ -408,6 +408,14 @@
                                     <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
                                 </artifactItem>
 
+                                <!-- 4.10 -->
+                                <artifactItem>
+                                    <groupId>org.apache.camel</groupId>
+                                    <artifactId>camel-platform-http</artifactId>
+                                    <version>${camel4.10-version}</version>
+                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
+                                </artifactItem>
+
                                 <!-- Apache HTTP Client -->
                                 <artifactItem>
                                     <groupId>org.apache.httpcomponents</groupId>

--- a/camel-upgrade-recipes/src/main/resources/META-INF/rewrite/4.11.yaml
+++ b/camel-upgrade-recipes/src/main/resources/META-INF/rewrite/4.11.yaml
@@ -1,0 +1,64 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#####
+# Rules coming from https://camel.apache.org/manual/camel-4x-upgrade-guide-4_11.html
+#####
+
+#####
+# Update the Camel project from 4.10 to 4.11
+#####
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.apache.camel.upgrade.camel411.CamelMigrationRecipe
+displayName: Migrates `camel 4.10` application to `camel 4.11`
+description: Migrates `camel 4.10` application to `camel 4.11`.
+recipeList:
+  - org.apache.camel.upgrade.camel411.platformHttpFilterStrategy
+  - org.apache.camel.upgrade.camel411.removedDependencies
+  - org.apache.camel.upgrade.camel411.removedLightweight
+---
+#https://camel.apache.org/manual/camel-4x-upgrade-guide-4_11.html#_camel_platform_http
+type: specs.openrewrite.org/v1beta/recipe
+name: org.apache.camel.upgrade.camel411.platformHttpFilterStrategy
+displayName: Use PlatformHttpHeaderFilterStrategy instead of HttpHeaderFilterStrategy
+description: PlatformHttpHeaderFilterStrategy is removed, use HttpHeaderFilterStrategy instead.
+recipeList:
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.platform.http.PlatformHttpHeaderFilterStrategy
+      newFullyQualifiedTypeName: org.apache.camel.http.base.HttpHeaderFilterStrategy
+---
+#https://camel.apache.org/manual/camel-4x-upgrade-guide-4_11.html#_camel_etcd3
+type: specs.openrewrite.org/v1beta/recipe
+name: org.apache.camel.upgrade.camel411.removedDependencies
+displayName: Removed deprecated components
+description: Removed deprecated components (camel-etcd3).
+recipeList:
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: org.apache.camel
+      artifactId: camel-etcd3
+---
+#https://camel.apache.org/manual/camel-4x-upgrade-guide-4_11.html#_camel_main
+type: specs.openrewrite.org/v1beta/recipe
+name: org.apache.camel.upgrade.camel411.removedLightweight
+displayName: Removed deprecated property camel.main.lightweight
+description: Removed deprecated configuration properties (camel.main.lightweight).
+recipeList:
+  - org.openrewrite.yaml.DeleteProperty:
+      propertyKey: camel.main.lightweight
+  - org.openrewrite.properties.DeleteProperty:
+      propertyKey: camel.main.lightweight

--- a/camel-upgrade-recipes/src/main/resources/META-INF/rewrite/latest.yaml
+++ b/camel-upgrade-recipes/src/main/resources/META-INF/rewrite/latest.yaml
@@ -20,6 +20,7 @@ name: org.apache.camel.upgrade.CamelMigrationRecipe
 displayName: Migrate to @camel-version@
 description: Migrates Apache Camel application to @camel-version@
 recipeList:
+  - org.apache.camel.upgrade.camel411.CamelMigrationRecipe
   - org.apache.camel.upgrade.camel410.CamelMigrationRecipe
   - org.apache.camel.upgrade.camel49.CamelMigrationRecipe
   - org.apache.camel.upgrade.camel47.CamelMigrationRecipe

--- a/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelTestUtil.java
+++ b/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelTestUtil.java
@@ -46,7 +46,8 @@ public class CamelTestUtil {
         v4_7(4, 7, 0),
         v4_8(4, 8, 0),
         v4_9(4, 9, 0),
-        v4_10(4, 10, 0);
+        v4_10(4, 10, 0),
+        v4_11(4, 11, 0);
 
         private int major;
         private int minor;

--- a/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelUpdate411Test.java
+++ b/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelUpdate411Test.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.upgrade;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
+
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.maven.Assertions.pomXml;
+import static org.openrewrite.properties.Assertions.properties;
+import static org.openrewrite.xml.Assertions.xml;
+
+public class CamelUpdate411Test implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        CamelTestUtil.recipe(spec, CamelTestUtil.CamelVersion.v4_11)
+                .parser(CamelTestUtil.parserFromClasspath(CamelTestUtil.CamelVersion.v4_10, "camel-platform-http"))
+                .typeValidationOptions(TypeValidation.none());
+    }
+
+    /**
+     * <a href="https://github.com/apache/camel/blob/main/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_10.adoc#camel-smb">camel-smb</a>
+     */
+    @Test
+    public void testPlatformHttpFilterStrategy() {
+        //language=java
+        rewriteRun(java(
+                """
+                             import org.apache.camel.component.platform.http.PlatformHttpHeaderFilterStrategy;
+                             
+                             public class SmbTest {
+                                 public void test() {
+                                        PlatformHttpHeaderFilterStrategy strategy = new PlatformHttpHeaderFilterStrategy();
+                                 }
+                             }
+                        """,
+                """
+                             import org.apache.camel.http.base.HttpHeaderFilterStrategy;
+                             
+                             public class SmbTest {
+                                 public void test() {
+                                        HttpHeaderFilterStrategy strategy = new HttpHeaderFilterStrategy();
+                                 }
+                             }
+                        """));
+    }
+
+    /**
+     * <a href="https://github.com/apache/camel/blob/main/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_10.adoc#camel-smb">camel-smb</a>
+     */
+    @Test
+    public void testLightweightRemoval() {
+        //language=java
+        rewriteRun(
+                properties(
+                        """
+                          camel.main.lightweight=true
+                          camel.main.other_properties=true
+                          """,
+                        """
+                          camel.main.other_properties=true
+                          """
+                )
+        );
+    }
+
+
+    /**
+     * Removed camel-etcd3.
+     *
+     * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_11.html#_camel_etcd3">Removed deprecated components</a>
+     */
+    @Test
+    public void testRemovedDependencies() {
+        //language=xml
+        rewriteRun(pomXml(
+                """
+                        <project>
+                           <modelVersion>4.0.0</modelVersion>
+
+                           <artifactId>test</artifactId>
+                           <groupId>org.apache.camel.test</groupId>
+                           <version>1.0.0</version>
+
+                           <properties>
+                               <camel.version>4.10.0</camel.version>
+                           </properties>
+
+                           <dependencies>
+                               <dependency>
+                                   <groupId>org.apache.camel</groupId>
+                                   <artifactId>camel-api</artifactId>
+                                   <version>${camel.version}</version>
+                               </dependency>
+                               <dependency>
+                                   <groupId>org.apache.camel</groupId>
+                                   <artifactId>camel-etcd3</artifactId>
+                                   <version>${camel.version}</version>
+                               </dependency>
+                            </dependencies>
+
+                        </project>
+                        """,
+                """
+                        <project>
+                           <modelVersion>4.0.0</modelVersion>
+
+                           <artifactId>test</artifactId>
+                           <groupId>org.apache.camel.test</groupId>
+                           <version>1.0.0</version>
+
+                           <properties>
+                               <camel.version>4.10.0</camel.version>
+                           </properties>
+
+                           <dependencies>
+                               <dependency>
+                                   <groupId>org.apache.camel</groupId>
+                                   <artifactId>camel-api</artifactId>
+                                   <version>${camel.version}</version>
+                               </dependency>
+                            </dependencies>
+
+                        </project>
+                        """));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,7 @@
         <camel4.6-version>4.6.0</camel4.6-version>
         <camel4.8-version>4.8.0</camel4.8-version>
         <camel4.9-version>4.9.0</camel4.9-version>
+        <camel4.10-version>4.10.0</camel4.10-version>
 
         <camel-version>${project.version}</camel-version>
         <camel-spring-boot-version>${project.version}</camel-spring-boot-version>


### PR DESCRIPTION
fixes https://github.com/apache/camel-upgrade-recipes/issues/28

Recipes for upgrade to Camel 4.11 (see [guide](https://camel.apache.org/manual/camel-4x-upgrade-guide-4_11.html))

Covered are following topics (others can not be covered):

- [camel-main](https://camel.apache.org/manual/camel-4x-upgrade-guide-4_11.html#_camel_main)
- [camel-platform-http](https://camel.apache.org/manual/camel-4x-upgrade-guide-4_11.html#_camel_platform_http)
- [camel-etcd3](https://camel.apache.org/manual/camel-4x-upgrade-guide-4_11.html#_camel_etcd3)