### PR TITLE
Move properties from camel-spring-boot-upgrade-recipes pom.xml up to root pom.xml for easier maintenance

### DIFF
--- a/camel-spring-boot-upgrade-recipes/pom.xml
+++ b/camel-spring-boot-upgrade-recipes/pom.xml
@@ -28,12 +28,6 @@
 
     <artifactId>camel-spring-boot-upgrade-recipes</artifactId>
 
-    <properties>
-        <!-- Use same version as https://github.com/apache/camel-spring-boot/blob/${project.version}/pom.xml#L111C9-L111C57 -->
-        <spring-boot-version>3.4.2</spring-boot-version>
-        <springframework-version>6.2.2</springframework-version>
-    </properties>
-
     <name>Camel Spring Boot Upgrades Recipes</name>
     <description>Migration recipes (using openrewrite) for Camel Spring Boot to make Maven migrations easier</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,10 @@
         <camel-version>${project.version}</camel-version>
         <camel-spring-boot-version>${project.version}</camel-spring-boot-version>
 
+        <!-- versions for camel-spring-boot -->
+        <spring-boot-version>3.4.2</spring-boot-version>
+        <springframework-version>6.2.2</springframework-version>
+
         <rewrite-recipe-bom.version>3.0.2</rewrite-recipe-bom.version>
 
         <lombok.version>1.18.34</lombok.version>


### PR DESCRIPTION
Moving the properties from the camel-spring-boot-upgrade-recipes/pom.xml up to the root pom.xml just to make maintenance in the future easier.