### PR TITLE
Bump rewrite to 3.9.0

### DIFF
--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel40/yaml/CamelYamlRouteConfigurationSequenceRecipe.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel40/yaml/CamelYamlRouteConfigurationSequenceRecipe.java
@@ -109,7 +109,7 @@ public class CamelYamlRouteConfigurationSequenceRecipe extends Recipe {
                     }
                     Yaml.Mapping.Entry resultr = e.withValue(new Yaml.Mapping(
                             randomId(), sequenceToReplace.getMarkers(), sequenceToReplace.getOpeningBracketPrefix(), entries,
-                            null, null));
+                            null, null, null));
 
                     if (!indentRegistered) {
                         indentRegistered = true;

--- a/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelUpdate45Test.java
+++ b/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelUpdate45Test.java
@@ -151,24 +151,55 @@ public class CamelUpdate45Test implements RewriteTest {
      * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_5.html#_camel_elasticsearch_camel_opensearch">CAMEL-ELASTICSEARCH/CAMEL-OPENSEARCH</a>
      */
     @Test
-    public void testSearch() {
+    public void testElasticSearch() {
         //language=java
         rewriteRun(java(
                 """
+                            import org.apache.camel.component.es.aggregation.BulkRequestAggregationStrategy;
+                            
                             public class SearchTest {
                                  public void test() {
                              
-                                     org.apache.camel.component.es.aggregation.BulkRequestAggregationStrategy elasticAggregationStrategy = null;
-                                     org.apache.camel.component.opensearch.aggregation.BulkRequestAggregationStrategy openAggregationStrategy = null;
+                                     BulkRequestAggregationStrategy elasticAggregationStrategy = null;
                                  }
                             }
                         """,
                 """
+                            import org.apache.camel.component.es.aggregation.ElastichsearchBulkRequestAggregationStrategy;
+                            
                             public class SearchTest {
                                  public void test() {
                             
-                                     org.apache.camel.component.es.aggregation.ElastichsearchBulkRequestAggregationStrategy elasticAggregationStrategy = null;
-                                     org.apache.camel.component.opensearch.aggregation.OpensearchBulkRequestAggregationStrategy openAggregationStrategy = null;
+                                     ElastichsearchBulkRequestAggregationStrategy elasticAggregationStrategy = null;                                   
+                                 }
+                            }
+                        """));
+    }
+
+    /**
+     * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_5.html#_camel_elasticsearch_camel_opensearch">CAMEL-ELASTICSEARCH/CAMEL-OPENSEARCH</a>
+     */
+    @Test
+    public void testOpenSearch() {
+        //language=java
+        rewriteRun(java(
+                """
+                            import org.apache.camel.component.opensearch.aggregation.BulkRequestAggregationStrategy;
+                            
+                            public class SearchTest {
+                                 public void test() {
+                             
+                                     BulkRequestAggregationStrategy elasticAggregationStrategy = null;
+                                 }
+                            }
+                        """,
+                """
+                            import org.apache.camel.component.opensearch.aggregation.OpensearchBulkRequestAggregationStrategy;
+                            
+                            public class SearchTest {
+                                 public void test() {
+                            
+                                     OpensearchBulkRequestAggregationStrategy elasticAggregationStrategy = null;                                   
                                  }
                             }
                         """));

--- a/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelUpdate46Test.java
+++ b/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelUpdate46Test.java
@@ -211,9 +211,6 @@ public class CamelUpdate46Test implements RewriteTest {
                         
                         public class LangchainTest {
                             public void test() {
-                                org.apache.camel.component.chat.LangChainChatComponent langChainChatComponent;
-                                org.apache.camel.component.chat.LangChainChatConfiguration  langChainChatConfiguration;
-                                org.apache.camel.component.chat.LangChainChatEndpoint langChainChatEndpoint;
                                 LangChainChat langChainChat;
                                 LangChainChatOperations langChainChatOperations;
                                 LangChainChatProducer langChainChatProducer;
@@ -227,12 +224,44 @@ public class CamelUpdate46Test implements RewriteTest {
                         
                         public class LangchainTest {
                             public void test() {
-                                org.apache.camel.component.langchain4j.chat.LangChain4jChatComponent langChainChatComponent;
-                                org.apache.camel.component.langchain4j.chat.LangChain4jChatConfiguration  langChainChatConfiguration;
-                                org.apache.camel.component.langchain4j.chat.LangChain4jChatEndpoint langChainChatEndpoint;
                                 LangChain4jChat langChainChat;
                                 LangChain4jChatOperations langChainChatOperations;
                                 LangChain4jChatProducer langChainChatProducer;
+                            }
+                        }
+                        """));
+    }
+
+    /**
+     * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_6.html#_camel_langchain4j_chat">CAMEL-LANGCHAIN4J-CHAT</a>
+     */
+    @Test
+    public void testLangchainChat2() {
+        //language=java
+        rewriteRun(java(
+                """
+                        import org.apache.camel.component.chat.LangChainChatComponent;
+                        import org.apache.camel.component.chat.LangChainChatConfiguration;
+                        import org.apache.camel.component.chat.LangChainChatEndpoint;
+                        
+                        public class LangchainTest {
+                            public void test() {
+                                LangChainChatComponent langChainChatComponent;
+                                LangChainChatConfiguration  langChainChatConfiguration;
+                                LangChainChatEndpoint langChainChatEndpoint;
+                            }
+                        }
+                        """,
+                """
+                        import org.apache.camel.component.langchain4j.chat.LangChain4jChatComponent;
+                        import org.apache.camel.component.langchain4j.chat.LangChain4jChatConfiguration;
+                        import org.apache.camel.component.langchain4j.chat.LangChain4jChatEndpoint;
+                        
+                        public class LangchainTest {
+                            public void test() {
+                                LangChain4jChatComponent langChainChatComponent;
+                                LangChain4jChatConfiguration  langChainChatConfiguration;
+                                LangChain4jChatEndpoint langChainChatEndpoint;
                             }
                         }
                         """));
@@ -255,9 +284,6 @@ public class CamelUpdate46Test implements RewriteTest {
                                 LangChainEmbeddingsComponent langChainEmbeddingsComponent;
                                 LangChainEmbeddingsConfiguration langChainEmbeddingsConfiguration;
                                 LangChainEmbeddingsConverter langChainEmbeddingsConverter;
-                                org.apache.camel.component.langchain.embeddings.LangChainEmbeddingsEndpoint langChainEmbeddingsEndpoint;
-                                org.apache.camel.component.langchain.embeddings.LangChainEmbeddings langChainEmbeddings;
-                                org.apache.camel.component.langchain.embeddings.LangChainEmbeddingsProducer langChainEmbeddingsProducer;
                             }
                         }
                         """,
@@ -271,9 +297,41 @@ public class CamelUpdate46Test implements RewriteTest {
                                 LangChain4jEmbeddingsComponent langChainEmbeddingsComponent;
                                 LangChain4jEmbeddingsConfiguration langChainEmbeddingsConfiguration;
                                 LangChain4jEmbeddingsConverter langChainEmbeddingsConverter;
-                                org.apache.camel.component.langchain4j.embeddings.LangChain4jEmbeddingsEndpoint langChainEmbeddingsEndpoint;
-                                org.apache.camel.component.langchain4j.embeddings.LangChain4jEmbeddings langChainEmbeddings;
-                                org.apache.camel.component.langchain4j.embeddings.LangChain4jEmbeddingsProducer langChainEmbeddingsProducer;
+                            }
+                        }
+                        """));
+    }
+
+    /**
+     * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_6.html#_camel_langchain4j_embeddingsat">CAMEL-LANGCHAIN4J-EMBEDDINGS</a>
+     */
+    @Test
+    public void testLangchainEmbeddings2() {
+        //language=java
+        rewriteRun(java(
+                """
+                        import org.apache.camel.component.langchain.embeddings.LangChainEmbeddingsEndpoint;
+                        import org.apache.camel.component.langchain.embeddings.LangChainEmbeddings;
+                        import org.apache.camel.component.langchain.embeddings.LangChainEmbeddingsProducer;
+                        
+                        public class LangchainTest {
+                            public void test() {
+                                LangChainEmbeddingsEndpoint langChainEmbeddingsEndpoint;
+                                LangChainEmbeddings langChainEmbeddings;
+                                LangChainEmbeddingsProducer langChainEmbeddingsProducer;
+                            }
+                        }
+                        """,
+                """
+                        import org.apache.camel.component.langchain4j.embeddings.LangChain4jEmbeddings;
+                        import org.apache.camel.component.langchain4j.embeddings.LangChain4jEmbeddingsEndpoint;
+                        import org.apache.camel.component.langchain4j.embeddings.LangChain4jEmbeddingsProducer;
+                        
+                        public class LangchainTest {
+                            public void test() {
+                                LangChain4jEmbeddingsEndpoint langChainEmbeddingsEndpoint;
+                                LangChain4jEmbeddings langChainEmbeddings;
+                                LangChain4jEmbeddingsProducer langChainEmbeddingsProducer;
                             }
                         }
                         """));

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <spring-boot-version>3.5.0</spring-boot-version>
         <springframework-version>6.2.7</springframework-version>
 
-        <rewrite-recipe-bom.version>3.0.2</rewrite-recipe-bom.version>
+        <rewrite-recipe-bom.version>3.9.0</rewrite-recipe-bom.version>
 
         <lombok.version>1.18.34</lombok.version>
         <slf4j.version>1.7.36</slf4j.version>


### PR DESCRIPTION
ump rewrite to 3.9.0, so quarkus-updates is not blocked, see https://github.com/quarkusio/quarkus-updates/pull/309