### PR TITLE
[CAMEL-21862] camel-spring-boot - Remove deprecated camel.springboot. config prefix

### DIFF
--- a/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/4.13.yaml
+++ b/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/4.13.yaml
@@ -27,3 +27,12 @@ recipeList:
       oldArtifactId: camel-fury-starter
       newArtifactId: camel-fory-starter
 #  - any new CSB recipe for C4.13 goes here and to the latest.yaml
+  - org.apache.camel.upgrade.customRecipes.PropertiesAndYamlKeyUpdate:
+      oldPropertyKey: camel.springboot.main-run-controller
+      newPropertyKey: camel.main.run-controller
+  - org.apache.camel.upgrade.customRecipes.PropertiesAndYamlKeyUpdate:
+      oldPropertyKey: camel.springboot.include-non-singletons
+      newPropertyKey: camel.main.include-non-singletons
+  - org.apache.camel.upgrade.customRecipes.PropertiesAndYamlKeyUpdate:
+      oldPropertyKey: camel.springboot.warn-on-early-shutdown
+      newPropertyKey: camel.main.warn-on-early-shutdown


### PR DESCRIPTION
Issue: https://issues.apache.org/jira/browse/CAMEL-21862

There were changes in property names:
1. _camel.**springboot.main**-run-controller_ -> _camel.**main**.run-controller_
See: https://github.com/apache/camel-spring-boot/blob/camel-spring-boot-4.13.0/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/CamelSpringBootApplicationListener.java#L114

2. _camel.**springboot**.include-non-singletons_ -> _camel.**main**.include-non-singletons_
See: https://github.com/apache/camel-spring-boot/blob/camel-spring-boot-4.13.0/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/CamelAutoConfiguration.java#L295

3. _camel.**springboot**.warn-on-early-shutdown_ -> _camel.**main**.warn-on-early-shutdown_
See: https://github.com/apache/camel-spring-boot/blob/camel-spring-boot-4.13.0/core/camel-spring-boot/src/main/java/org/apache/camel/spring/boot/CamelAutoConfiguration.java#L110

I know there are also some tests in this project. Could you please help me with adding these changes to these tests?
