### PR TITLE
[CAMEL-21862] camel-spring-boot - Remove deprecated camel.springboot. config prefix

### DIFF
--- a/camel-spring-boot-upgrade-recipes/pom.xml
+++ b/camel-spring-boot-upgrade-recipes/pom.xml
@@ -37,6 +37,16 @@
             <artifactId>camel-upgrade-recipes</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.openrewrite</groupId>
+            <artifactId>rewrite-java-21</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openrewrite</groupId>
+            <artifactId>rewrite-maven</artifactId>
+            <scope>provided</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.openrewrite</groupId>

--- a/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/4.13.yaml
+++ b/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/4.13.yaml
@@ -17,8 +17,8 @@
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.apache.camel.upgrade.camel413.CamelSpringBootMigrationRecipe
-displayName: Migrates Camel Spring Boot applications to Camel Spring Boot 4.12
-description: Migrates Camel Spring Boot applications to Camel Spring Boot 4.12
+displayName: Migrates Camel Spring Boot applications to Camel Spring Boot 4.13
+description: Migrates Camel Spring Boot applications to Camel Spring Boot 4.13.
 recipeList:
   - org.apache.camel.upgrade.camel412.CamelSpringBootMigrationRecipe
   - org.apache.camel.upgrade.camel413.CamelMigrationRecipe
@@ -26,4 +26,12 @@ recipeList:
       oldGroupId: org.apache.camel-springboot
       oldArtifactId: camel-fury-starter
       newArtifactId: camel-fory-starter
-#  - any new CSB recipe for C4.13 goes here and to the latest.yaml
+  - org.apache.camel.upgrade.customRecipes.PropertiesAndYamlKeyUpdate:
+      oldPropertyKey: camel.springboot.main-run-controller
+      newPropertyKey: camel.main.run-controller
+  - org.apache.camel.upgrade.customRecipes.PropertiesAndYamlKeyUpdate:
+      oldPropertyKey: camel.springboot.include-non-singletons
+      newPropertyKey: camel.main.include-non-singletons
+  - org.apache.camel.upgrade.customRecipes.PropertiesAndYamlKeyUpdate:
+      oldPropertyKey: camel.springboot.warn-on-early-shutdown
+      newPropertyKey: camel.main.warn-on-early-shutdown

--- a/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/latest.yaml
+++ b/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/latest.yaml
@@ -77,3 +77,12 @@ recipeList:
       oldGroupId: org.apache.camel-springboot
       oldArtifactId: camel-fury-starter
       newArtifactId: camel-fory-starter
+  - org.apache.camel.upgrade.customRecipes.PropertiesAndYamlKeyUpdate:
+      oldPropertyKey: camel.springboot.main-run-controller
+      newPropertyKey: camel.main.run-controller
+  - org.apache.camel.upgrade.customRecipes.PropertiesAndYamlKeyUpdate:
+      oldPropertyKey: camel.springboot.include-non-singletons
+      newPropertyKey: camel.main.include-non-singletons
+  - org.apache.camel.upgrade.customRecipes.PropertiesAndYamlKeyUpdate:
+      oldPropertyKey: camel.springboot.warn-on-early-shutdown
+      newPropertyKey: camel.main.warn-on-early-shutdown

--- a/camel-spring-boot-upgrade-recipes/src/test/java/org/apache/camel/upgrade/springboot/CamelSpringBoot413Test.java
+++ b/camel-spring-boot-upgrade-recipes/src/test/java/org/apache/camel/upgrade/springboot/CamelSpringBoot413Test.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.upgrade.springboot;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.config.Environment;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.properties.Assertions.properties;
+import static org.openrewrite.yaml.Assertions.yaml;
+
+class CamelSpringBoot413Test implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(Environment.builder()
+                .scanYamlResources()
+                .build()
+                .activateRecipes("org.apache.camel.upgrade.camel413.CamelSpringBootMigrationRecipe"));
+    }
+
+    @DocumentExample
+    @Test
+    void testProperties() {
+        rewriteRun(
+                //both org.apache.camel.upgrade.camel413.CamelSpringBootMigrationRecipe and
+                // org.apache.camel.upgrade.UpdateCamelSpringBootPropertiesAndYamlKeys go modifies this properties
+                spec -> spec.expectedCyclesThatMakeChanges(2),
+            properties(
+                    """
+                      camel.springboot.main-run-controller=something
+                      camel.springboot.include-non-singletons=something
+                      camel.springboot.warn-on-early-shutdown=something
+                      """,
+                    """
+                      camel.main.run-controller=something
+                      camel.main.include-non-singletons=something
+                      camel.main.warn-on-early-shutdown=something
+                      """
+            )
+        );
+    }
+
+    @Test
+    void yamlFile() {
+        rewriteRun(
+                //both org.apache.camel.upgrade.camel413.CamelSpringBootMigrationRecipe and
+                // org.apache.camel.upgrade.UpdateCamelSpringBootPropertiesAndYamlKeys modifies this properties
+                spec -> spec.expectedCyclesThatMakeChanges(2),
+            yaml(
+                    """
+                      camel:
+                        springboot:
+                          main-run-controller: something
+                          name: 'Foo'
+                          routeControllerBackOffDelay: true
+                        main:
+                          routeControllerBackOffMultiplier: 5
+                      another:
+                        ignored:
+                          property: true
+                      """,
+                    """
+                        camel:
+                          main:
+                            name: 'Foo'
+                          routecontroller.backOffMultiplier: 5
+                          routecontroller.backOffDelay: true
+                          main.runController: something
+                        another:
+                          ignored:
+                            property: true
+                      """
+            )
+        );
+    }
+
+}


### PR DESCRIPTION
fixes https://issues.apache.org/jira/browse/CAMEL-21862

replaces https://github.com/apache/camel-upgrade-recipes/pull/46

Used original PR plus:
* added test for the `org.apache.camel.upgrade.camel413.CamelSpringBootMigrationRecipe`
* addded new recipes into latest.yml

@Croway The `exclusions` should probably stay, because the removal does not affect recipes in this PR. If removed, the test `CamelSpringBootPropertiesTest` would need to be changed, as the migration would need to do more cycles through the sources (which is better to be avoided)