### PR TITLE
Create GitHub releases for tags

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -1,0 +1,38 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Create GitHub Release
+# This workflow creates a GitHub release when a tag is pushed, such that folks can subscribe to releases in GitHub
+
+on:
+  push:
+    tags:
+      - [0-9]+.[0-9]+.[0-9]+
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Create GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+              --repo="$GITHUB_REPOSITORY" \
+              --title="${{ github.ref_name }}" \
+              --generate-notes


### PR DESCRIPTION
Hi! This a quick request to make it easier to track new releases right from GitHub. I'm a fan of the "Watch > Custom > Releases" option, and I imagine I'm not the only one.
<img width="533" height="438" alt="image" src="https://github.com/user-attachments/assets/9875311d-c0e1-4240-9f66-90ab7b3f2cd7" />

This workflow would run whenever a tag is pushed to create a matching release on this page of the repository:
- https://github.com/apache/camel-upgrade-recipes/releases

No further changes to the release process needed; this just runs on tags and uses a built in support from GitHub tokens & CLI.

No harm of course if this is not to your liking; it was just as much effort to open a PR as an issue would have been, so feel free to adopt or close.