### PR TITLE
Extract recipe (and test) for 4.10.4 - so Quarkus-updates can resuse it

### DIFF
--- a/camel-upgrade-recipes/src/main/resources/META-INF/rewrite/4.10.4.yaml
+++ b/camel-upgrade-recipes/src/main/resources/META-INF/rewrite/4.10.4.yaml
@@ -1,0 +1,24 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.apache.camel.upgrade.camel410_4.CamelMigrationRecipe
+displayName: Migrates `camel 4.10.3` application to `camel 4.10.4`
+description: Migrates `camel 4.10.3` application to `camel 4.10.4`.
+recipeList:
+# 4.10.3 to 4.10.4 java dsl - https://camel.apache.org/manual/camel-4x-upgrade-guide-4_10.html#_java_dsl
+  - org.apache.camel.upgrade.camel412.Java412Recipes

--- a/camel-upgrade-recipes/src/main/resources/META-INF/rewrite/4.10LTS.yaml
+++ b/camel-upgrade-recipes/src/main/resources/META-INF/rewrite/4.10LTS.yaml
@@ -20,6 +20,7 @@ name: org.apache.camel.upgrade.Camel410LTSMigrationRecipe
 displayName: Migrate to @camel4.10-lts-version@
 description: Migrates Apache Camel application to @camel4.10-lts-version@.
 recipeList:
+  - org.apache.camel.upgrade.camel410_4.CamelMigrationRecipe
   - org.apache.camel.upgrade.camel410.CamelMigrationRecipe
   - org.apache.camel.upgrade.camel49.CamelMigrationRecipe
   - org.apache.camel.upgrade.camel47.CamelMigrationRecipe
@@ -30,10 +31,6 @@ recipeList:
   - org.apache.camel.upgrade.UpgradeToJava17
   - org.apache.camel.upgrade.JavaVersion17
   - org.apache.camel.upgrade.UpdatePropertiesAndYamlKeys
-# 4.10.3 to 4.10.4 java dsl - https://camel.apache.org/manual/camel-4x-upgrade-guide-4_10.html#_java_dsl
-  - org.apache.camel.upgrade.camel412.Java412Recipes
-  - org.apache.camel.upgrade.camel412.xmlDslBearer
-  - org.apache.camel.upgrade.camel412.yamlDslBearer
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: 'org.apache.camel'
       artifactId: '*'

--- a/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelTestUtil.java
+++ b/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelTestUtil.java
@@ -45,6 +45,7 @@ public class CamelTestUtil {
         v4_8(4, 8, 0),
         v4_9(4, 9, 0),
         v4_10(4, 10, 0),
+        v4_10_4(4, 10, 4, true),
         v4_11(4, 11, 0),
         v4_12(4, 12, 0),
         v4_13(4, 13, 0),
@@ -53,27 +54,40 @@ public class CamelTestUtil {
         private int major;
         private int minor;
         private int patch;
+        private boolean lts;
 
         CamelVersion(int major, int minor, int patch) {
+            this(major, minor, patch, false);
+        }
+
+        CamelVersion(int major, int minor, int patch, boolean lts) {
             this.major = major;
             this.minor = minor;
             this.patch = patch;
+            this.lts = lts;
         }
 
         public String getVersion() {
-            return getMajorMinor() + "." + patch;
+            return getRecipeFile() + "." + patch;
         }
 
-        public String getMajorMinor() {
+        private String getRecipeFile() {
+            if(lts) {
+                return major + "." + minor + "." + patch;
+            }
             return major + "." + minor;
         }
 
         public String getYamlFile() {
-            return "/META-INF/rewrite/" + getMajorMinor() + ".yaml";
+            return "/META-INF/rewrite/" + getRecipeFile() + ".yaml";
         }
 
         public String getRecipe() {
+            if(lts) {
+                return "org.apache.camel.upgrade.camel" + major + minor + "_" + patch + ".CamelMigrationRecipe";
+            }
             return "org.apache.camel.upgrade.camel" + major + minor + ".CamelMigrationRecipe";
+
         }
 
     }

--- a/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelUpdate410_4Test.java
+++ b/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelUpdate410_4Test.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.upgrade;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
+
+//class has to stay public, because test is extended in project quarkus-updates
+public class CamelUpdate410_4Test implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        CamelTestUtil.recipe(spec, CamelTestUtil.CamelVersion.v4_10_4)
+                .parser(CamelTestUtil.parserFromClasspath(CamelTestUtil.CamelVersion.v4_10, "camel-api",
+                        "camel-core-model", "camel-support"))
+                .typeValidationOptions(TypeValidation.none());
+    }
+
+    /**
+     * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_10.html#_java_dsl">Java DSL</a>
+     * ,which is covered by CamelUpdate412Test#javaDslChoice
+     */
+    @Test
+    void javaDslChoice() {
+       new CamelUpdate412Test().javaDslChoice();
+    }
+
+}

--- a/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/camel410lts/CamelUpdate410LtsVersionTest.java
+++ b/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/camel410lts/CamelUpdate410LtsVersionTest.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 //class has to stay public, because test is extended in project quarkus-updates
 @EnabledIfSystemProperty(named = CamelTestUtil.PROPERTY_USE_RECIPE, matches = "org.apache.camel.upgrade.Camel410LTSMigrationRecipe")
-public class CamelUpdate410LTSVersionTest  extends AbstractCamelUpdateVersionTest {
+public class CamelUpdate410LtsVersionTest extends AbstractCamelUpdateVersionTest {
 
 
     @Override


### PR DESCRIPTION
Extracted recipe (and test) for following use in Quarkus-updates. Does not change any functionality or use for plain Camel.

@Croway I'm just thinking, do you need to create a special recipe for CSB 4.10.4 (or 4.10lts) as well?