### PR TITLE
Update OpenRewrite and remove Camel 4.8 dependencies from classpath

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ components/camel-cxf/activemq-data
 node_modules/
 mvnd.zip*
 .camel-jbang
+classpath.tsv.gz

--- a/camel-upgrade-recipes/pom.xml
+++ b/camel-upgrade-recipes/pom.xml
@@ -110,19 +110,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.camel</groupId>
-            <artifactId>camel-core-engine</artifactId>
-            <version>${camel4.8-version}</version>
-        </dependency>
-
-
-        <dependency>
-            <groupId>org.apache.camel</groupId>
-            <artifactId>camel-core-languages</artifactId>
-            <version>${camel4.8-version}</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-suite</artifactId>
             <version>1.13.4</version>

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
         <spring-boot-version>3.5.0</spring-boot-version>
         <springframework-version>6.2.7</springframework-version>
 
-        <rewrite-recipe-bom.version>3.9.0</rewrite-recipe-bom.version>
+        <rewrite-recipe-bom.version>3.15.0</rewrite-recipe-bom.version>
 
         <lombok.version>1.18.34</lombok.version>
         <slf4j.version>1.7.36</slf4j.version>
@@ -182,7 +182,7 @@
                     <plugin>
                         <groupId>org.openrewrite.maven</groupId>
                         <artifactId>rewrite-maven-plugin</artifactId>
-                        <version>6.15.0</version>
+                        <version>6.19.0</version>
                         <configuration>
                             <activeRecipes>
                                 <recipe>org.apache.camel.upgrade.internal.OpenRewriteRecipeBestPractices</recipe>
@@ -193,7 +193,7 @@
                             <dependency>
                                 <groupId>org.openrewrite.recipe</groupId>
                                 <artifactId>rewrite-rewrite</artifactId>
-                                <version>0.10.1</version>
+                                <version>0.13.0</version>
                             </dependency>
                         </dependencies>
                     </plugin>


### PR DESCRIPTION
THe Camel 4.8 dependency in use is flagged with a CVE, also, the dependency is not used.