### PR TITLE
Upgade Camel to 4.15.0

### DIFF
--- a/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/4.15.yaml
+++ b/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/4.15.yaml
@@ -1,0 +1,24 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.apache.camel.upgrade.camel415.CamelSpringBootMigrationRecipe
+displayName: Migrates Camel Spring Boot applications to Camel Spring Boot 4.15
+description: Migrates Camel Spring Boot applications to Camel Spring Boot 4.15.
+recipeList:
+  - org.apache.camel.upgrade.camel414.CamelSpringBootMigrationRecipe
+  - org.apache.camel.upgrade.camel415.CamelMigrationRecipe

--- a/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/latest.yaml
+++ b/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/latest.yaml
@@ -21,6 +21,7 @@ displayName: Migrate to Apache Camel Spring Boot @camel-latest-version@
 description: >- 
   Migrate applications to Apache Camel Spring Boot @camel-latest-version@ and Spring Boot @spring-boot-version@
 recipeList:
+  - org.apache.camel.upgrade.camel415.CamelMigrationRecipe
   - org.apache.camel.upgrade.camel414.CamelMigrationRecipe
   - org.apache.camel.upgrade.camel413.CamelMigrationRecipe
   - org.apache.camel.upgrade.camel412.CamelMigrationRecipe

--- a/camel-upgrade-recipes/pom.xml
+++ b/camel-upgrade-recipes/pom.xml
@@ -128,6 +128,20 @@
             <version>1.13.4</version>
             <scope>test</scope>
         </dependency>
+
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-api</artifactId>
+                <version>5.13.4</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
+                <version>5.13.4</version>
+                <scope>test</scope>
+            </dependency>
+
     </dependencies>
 
     <build>
@@ -455,6 +469,50 @@
                                     <groupId>org.apache.camel</groupId>
                                     <artifactId>camel-core-model</artifactId>
                                     <version>${camel4.12-version}</version>
+                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
+                                </artifactItem>
+
+                                <!-- 4.1 -->
+                                <artifactItem>
+                                    <groupId>org.apache.camel</groupId>
+                                    <artifactId>camel-langchain4j-chat</artifactId>
+                                    <version>${camel4.14-version}</version>
+                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.camel</groupId>
+                                    <artifactId>camel-langchain4j-embeddings</artifactId>
+                                    <version>${camel4.14-version}</version>
+                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.camel</groupId>
+                                    <artifactId>camel-milvus</artifactId>
+                                    <version>${camel4.14-version}</version>
+                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.camel</groupId>
+                                    <artifactId>camel-neo4j</artifactId>
+                                    <version>${camel4.14-version}</version>
+                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.camel</groupId>
+                                    <artifactId>camel-pinecone</artifactId>
+                                    <version>${camel4.14-version}</version>
+                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.camel</groupId>
+                                    <artifactId>camel-qdrant</artifactId>
+                                    <version>${camel4.14-version}</version>
+                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.camel</groupId>
+                                    <artifactId>camel-weaviate</artifactId>
+                                    <version>${camel4.14-version}</version>
                                     <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
                                 </artifactItem>
 

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/RecipesUtil.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/RecipesUtil.java
@@ -16,6 +16,7 @@
  */
 package org.apache.camel.upgrade;
 
+import org.jspecify.annotations.Nullable;
 import org.openrewrite.*;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.*;
@@ -25,6 +26,7 @@ import org.openrewrite.yaml.tree.Yaml;
 
 import java.util.*;
 import java.util.function.Function;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static org.openrewrite.Tree.randomId;
@@ -289,6 +291,28 @@ public class RecipesUtil {
         return kebabCasePattern
                 .matcher(kebabCase)
                 .replaceAll(mr -> mr.group(1).toUpperCase());
+    }
+
+    public static @Nullable String getValueFromScalar(Yaml y) {
+        if(y instanceof Yaml.Scalar) {
+            return ((Yaml.Scalar) y).getValue();
+        }
+        return null;
+    }
+
+    public static @Nullable String replacePropertyInUrl(String uri, String component, String oldProperty, String newProperty, String optionalValuePrefix) {
+        if(uri.startsWith(component) && uri.contains(oldProperty)) {
+
+            if(optionalValuePrefix != null) {
+                Matcher m = Pattern.compile(String.format("(^%s[:?].*)%s=(['\"]?.+$)", component, oldProperty)).matcher(uri);
+                if (m.find()) {
+                    return m.group(1) + newProperty + "=" + optionalValuePrefix + m.group(2);
+                }
+            } else {
+                throw new IllegalArgumentException("Replace without prefix is not implemented yet!");
+            }
+        }
+        return null;
     }
 
 }

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/customRecipes/ReplacePropertyInComponentXml.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/customRecipes/ReplacePropertyInComponentXml.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.upgrade.customRecipes;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import org.apache.camel.upgrade.AbstractCamelXmlVisitor;
+import org.apache.camel.upgrade.RecipesUtil;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Option;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.xml.XPathMatcher;
+import org.openrewrite.xml.tree.Xml;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
+@AllArgsConstructor
+@Setter
+public class ReplacePropertyInComponentXml extends Recipe {
+
+    private static final XPathMatcher FROM_MATCHER = new XPathMatcher("//route/from");
+    private static final XPathMatcher TO_MATCHER = new XPathMatcher("//route/to");
+
+
+    @Option(example = "TODO Provide a usage example for the docs", displayName = "Component",
+            description = "Component name.")
+    String component;
+
+    @Option(example = "TODO Provide a usage example for the docs", displayName = "Old property key",
+            description = "The property key to rename.")
+    String oldPropertyKey;
+
+    @Option(example = "TODO Provide a usage example for the docs", displayName = "New prefix before any group",
+            description = "The prefix to be replaced with.")
+    String newPropertyKey;
+
+    @Option(example = "file:", displayName = "New prefix before value of the changed property",
+            description = "This value is appended before the current value of the modified method.",
+            required = false)
+    String valuePrefix;
+
+    @Override
+    public String getDisplayName() {
+        return "Camel XMl DSL changes";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Apache Camel XML DSL migration from version 4.9 o 4.10.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new AbstractCamelXmlVisitor() {
+
+            @Override
+            public Xml.Tag doVisitTag(final Xml.Tag tag, final ExecutionContext ctx) {
+                Xml.Tag t = super.doVisitTag(tag, ctx);
+
+                if(FROM_MATCHER.matches(getCursor())) {
+                    return replacePropertyIfPossible(t);
+                }
+                if(TO_MATCHER.matches(getCursor())) {
+                    return replacePropertyIfPossible(t);
+                }
+
+                return t;
+            }
+        };
+    }
+
+    private Xml.Tag replacePropertyIfPossible(final Xml.Tag tag) {
+
+        List<Xml.Attribute> attributes = new ArrayList<>(tag.getAttributes());
+
+        Optional<Xml.Attribute> uri = attributes.stream().filter(a -> "uri".equals(a.getKey().getName())).findAny();
+        if(uri.isPresent() && (component.equals(uri.get().getValue().getValue()) || uri.get().getValue().getValue().startsWith(component + ":"))) {
+            String u = uri.get().getValue().getValue();
+            //replace property and apply optionalPrefix
+            u = RecipesUtil.replacePropertyInUrl(u, component, oldPropertyKey, newPropertyKey, valuePrefix);
+            if(u != null) {
+                attributes.remove(uri.get());
+                attributes.add(uri.get().withValue(uri.get().getValue().withValue(u)));
+                return tag.withAttributes(attributes);
+            }
+        }
+        return tag;
+
+
+    }
+}

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/customRecipes/ReplacePropertyInComponentYaml.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/customRecipes/ReplacePropertyInComponentYaml.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.upgrade.customRecipes;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import org.apache.camel.upgrade.AbstractCamelYamlVisitor;
+import org.apache.camel.upgrade.RecipesUtil;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Option;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.yaml.search.FindKey;
+import org.openrewrite.yaml.tree.Yaml;
+
+import java.util.Optional;
+
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
+@AllArgsConstructor
+@Setter
+public class ReplacePropertyInComponentYaml extends Recipe {
+
+    @Option(example = "TODO Provide a usage example for the docs", displayName = "Component",
+            description = "Component name.")
+    String component;
+
+    @Option(example = "TODO Provide a usage example for the docs", displayName = "Old property key",
+            description = "The property key to rename.")
+    String oldPropertyKey;
+
+    @Option(example = "TODO Provide a usage example for the docs", displayName = "New prefix before any group",
+            description = "The prefix to be replaced with.")
+    String newPropertyKey;
+
+    @Option(example = "file:", displayName = "New prefix before value of the changed property",
+            description = "This value is appended before the current value of the modified method.",
+            required = false)
+    String valuePrefix;
+
+    @Override
+    public String getDisplayName() {
+        return "Renames property of the component";
+    }
+
+    @Override
+    public String getDescription() {
+        return "ARenames property of the component.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+
+        return new AbstractCamelYamlVisitor() {
+
+            @Override
+            protected void clearLocalCache() {
+                //nothing to do
+            }
+
+            @Override
+            public Yaml.Mapping.Entry doVisitMappingEntry(Yaml.Mapping.Entry entry, ExecutionContext ctx) {
+                Yaml.Mapping.Entry e = super.doVisitMappingEntry(entry, ctx);
+
+
+                String path = RecipesUtil.getProperty(getCursor());
+                //yaml fury marshal
+                if(path.endsWith("parameters." + oldPropertyKey)) {
+
+                    //find component type
+                    Optional<Yaml.Mapping.Entry> compYaml = FindKey.find(getCursor().getParent(3).getValue(), "$.uri").stream()
+                            .filter(o -> o instanceof Yaml.Mapping.Entry)
+                            .map(o -> (Yaml.Mapping.Entry)o)
+                            .findAny();
+
+                    if(compYaml.isPresent()) {
+                        String compName = RecipesUtil.getValueFromScalar(compYaml.get().getValue());
+
+                        if (compName != null && (component.equals(compName) || compName.startsWith(component + ":"))) {
+
+                            Yaml.Mapping.Entry newEntry = e.withKey(((Yaml.Scalar) entry.getKey().copyPaste()).withValue(newPropertyKey));
+
+                            if(valuePrefix != null && e.getValue() instanceof Yaml.Scalar && !((Yaml.Scalar)e.getValue()).getValue().startsWith(valuePrefix)) {
+                                newEntry = newEntry.withValue(((Yaml.Scalar)e.getValue()).copyPaste().withValue(valuePrefix + ((Yaml.Scalar) newEntry.getValue()).getValue()));
+                            }
+
+                            return newEntry;
+                        }
+                    }
+                }
+
+                return e;
+            }
+
+        };
+    }
+
+}

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/customRecipes/ReplacePropertyInDataFormatXml.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/customRecipes/ReplacePropertyInDataFormatXml.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.upgrade.customRecipes;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import org.apache.camel.upgrade.AbstractCamelXmlVisitor;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Option;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.xml.XPathMatcher;
+import org.openrewrite.xml.tree.Xml;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
+@AllArgsConstructor
+@Setter
+public class ReplacePropertyInDataFormatXml extends Recipe {
+
+
+    @Option(example = "TODO Provide a usage example for the docs", displayName = "Component",
+            description = "Component name.")
+    String component;
+
+    @Option(example = "TODO Provide a usage example for the docs", displayName = "Old property key",
+            description = "The property key to rename.")
+    String oldPropertyKey;
+
+    @Option(example = "TODO Provide a usage example for the docs", displayName = "New prefix before any group",
+            description = "The prefix to be replaced with.")
+    String newPropertyKey;
+
+    @Override
+    public String getDisplayName() {
+        return "Camel XMl DSL changes";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Apache Camel XML DSL migration from version 4.9 o 4.10.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new AbstractCamelXmlVisitor() {
+
+            @Override
+            public Xml.Tag doVisitTag(final Xml.Tag tag, final ExecutionContext ctx) {
+                Xml.Tag t = super.doVisitTag(tag, ctx);
+
+                if( new XPathMatcher("//marshal/" + component).matches(getCursor())) {
+                    return replacePropertyIfPossible(t);
+                }
+                return t;
+            }
+        };
+    }
+
+    private Xml.Tag replacePropertyIfPossible(final Xml.Tag tag) {
+
+        List<Xml.Attribute> attributes = new ArrayList<>(tag.getAttributes());
+
+        Optional<Xml.Attribute> property = attributes.stream().filter(a -> oldPropertyKey.equals(a.getKey().getName())).findAny();
+        if(property.isPresent()) {
+            attributes.remove(property.get());
+            attributes.add(property.get().withKey(property.get().getKey().withName(newPropertyKey)));
+            return tag.withAttributes(attributes);
+        }
+        return tag;
+    }
+}

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/customRecipes/ReplacePropertyInDataFormatYaml.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/customRecipes/ReplacePropertyInDataFormatYaml.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.upgrade.customRecipes;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import org.apache.camel.upgrade.AbstractCamelYamlVisitor;
+import org.apache.camel.upgrade.RecipesUtil;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Option;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.yaml.tree.Yaml;
+
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
+@AllArgsConstructor
+@Setter
+public class ReplacePropertyInDataFormatYaml extends Recipe {
+
+    @Option(example = "TODO Provide a usage example for the docs", displayName = "Component",
+            description = "Component name.")
+    String component;
+
+    @Option(example = "TODO Provide a usage example for the docs", displayName = "Old property key",
+            description = "The property key to rename.")
+    String oldPropertyKey;
+
+    @Option(example = "TODO Provide a usage example for the docs", displayName = "New prefix before any group",
+            description = "The prefix to be replaced with.")
+    String newPropertyKey;
+
+
+    @Override
+    public String getDisplayName() {
+        return "Renames property of the component";
+    }
+
+    @Override
+    public String getDescription() {
+        return "ARenames property of the component.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+
+        return new AbstractCamelYamlVisitor() {
+
+            @Override
+            protected void clearLocalCache() {
+                //nothing to do
+            }
+
+            @Override
+            public Yaml.Mapping.Entry doVisitMappingEntry(Yaml.Mapping.Entry entry, ExecutionContext ctx) {
+                Yaml.Mapping.Entry e = super.doVisitMappingEntry(entry, ctx);
+
+
+                String path = RecipesUtil.getProperty(getCursor());
+                //yaml fury marshal
+                if(path.endsWith("dataFormats." + component + "." + oldPropertyKey)) {
+                    return e.withKey(((Yaml.Scalar) e.getKey().copyPaste()).withValue(newPropertyKey));
+                }
+
+                return e;
+            }
+
+        };
+    }
+
+}

--- a/camel-upgrade-recipes/src/main/resources/META-INF/rewrite/4.15.yaml
+++ b/camel-upgrade-recipes/src/main/resources/META-INF/rewrite/4.15.yaml
@@ -1,0 +1,303 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#####
+# Rules coming from https://camel.apache.org/manual/camel-4x-upgrade-guide-4_15.html
+#####
+
+#####
+# Update the Camel project from 4.14 to 4.15
+#####
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.apache.camel.upgrade.camel415.CamelMigrationRecipe
+displayName: Migrates `camel 4.14` application to `camel 4.15`
+description: Migrates `camel 4.14` application to `camel 4.15`.
+recipeList:
+  - org.apache.camel.upgrade.camel415.aiNestedHeadersClasses
+  - org.apache.camel.upgrade.camel415.dataFormats
+  - org.apache.camel.upgrade.camel415.yamDataFormats
+  - org.apache.camel.upgrade.camel415.xmlDataFormats
+  - org.apache.camel.upgrade.camel415.nettyAndNettyHttp
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.apache.camel.upgrade.camel415.aiNestedHeadersClasses
+displayName: Changed types of camel AI nested headers classes
+description: Changed types of camel AI nested headers classes.
+recipeList:
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.langchain4j.chat.LangChain4jChat.Headers
+      newFullyQualifiedTypeName: org.apache.camel.component.langchain4j.chat.LangChain4jChatHeaders
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.langchain4j.embeddings.LangChain4jEmbeddings.Headers
+      newFullyQualifiedTypeName: org.apache.camel.component.langchain4j.embeddings.LangChain4jEmbeddingsHeaders
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.langchain4j.embeddingstore.LangChain4jEmbeddingStore.Headers
+      newFullyQualifiedTypeName: org.apache.camel.component.langchain4j.embeddingstore.LangChain4jEmbeddingStoreHeaders
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.milvus.Milvus.Headers
+      newFullyQualifiedTypeName: org.apache.camel.component.milvus.MilvusHeaders
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.neo4j.Neo4jConstants.Headers
+      newFullyQualifiedTypeName: org.apache.camel.component.neo4j.Neo4jHeaders
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.qdrant.Qdrant.Headers
+      newFullyQualifiedTypeName: org.apache.camel.component.qdrant.QdrantHeaders
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.pinecone.PineconeVectorDb.Headers
+      newFullyQualifiedTypeName: org.apache.camel.component.pinecone.PineconeVectorDbHeaders
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.weaviate.WeaviateVectorDb.Headers
+      newFullyQualifiedTypeName: org.apache.camel.component.weaviate.WeaviateVectorDbHeaders
+---
+#https://camel.apache.org/manual/camel-4x-upgrade-guide-4_15.html#_data_formats
+type: specs.openrewrite.org/v1beta/recipe
+name: org.apache.camel.upgrade.camel415.dataFormats
+displayName: Refactored dataFormats
+description: Refactored dataFormats.
+recipeList:
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: org.apache.camel.model.dataformat.CryptoDataFormat setAlgorithmParameterRef(String)
+      newMethodName: setAlgorithmParameterSpec
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: org.apache.camel.model.dataformat.CryptoDataFormat.Builder algorithmParameterRef(String)
+      newMethodName: algorithmParameterSpec
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: org.apache.camel.model.dataformat.CryptoDataFormat setKeyRef(String)
+      newMethodName: setKey
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: org.apache.camel.model.dataformat.CryptoDataFormat.Builder keyRef(String)
+      newMethodName: key
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: org.apache.camel.model.dataformat.CryptoDataFormat setInitVectorRef(String)
+      newMethodName: setInitVector
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: org.apache.camel.model.dataformat.CryptoDataFormat.Builder initVectorRef(String)
+      newMethodName: initVector
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: org.apache.camel.model.dataformat.CsvDataFormat setFormatRef(String)
+      newMethodName: setFormat
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: org.apache.camel.model.dataformat.CsvDataFormat.Builder formatRef(String)
+      newMethodName: format
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: org.apache.camel.model.dataformat.CsvDataFormat setFormatName(String)
+      newMethodName: setFormat
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: org.apache.camel.model.dataformat.CsvDataFormat.Builder formatName(String)
+      newMethodName: format
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: org.apache.camel.model.dataformat.FlatpackDataFormat setParserFactoryRef(String)
+      newMethodName: setParserFactory
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: org.apache.camel.model.dataformat.FlatpackDataFormat.Builder parserFactoryRef(String)
+      newMethodName: parserFactory
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: org.apache.camel.model.dataformat.JaxbDataFormat setNamespacePrefixRef(String)
+      newMethodName: setNamespacePrefix
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: org.apache.camel.model.dataformat.JaxbDataFormat.Builder namespacePrefixRef(String)
+      newMethodName: namespacePrefix
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: org.apache.camel.model.dataformat.SoapDataFormat setNamespacePrefixRef(String)
+      newMethodName: setNamespacePrefix
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: org.apache.camel.model.dataformat.SoapDataFormat.Builder namespacePrefixRef(String)
+      newMethodName: namespacePrefix
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: org.apache.camel.model.dataformat.SoapDataFormat setElementNameStrategyRef(String)
+      newMethodName: setElementNameStrategy
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: org.apache.camel.model.dataformat.SoapDataFormat.Builder elementNameStrategyRef(String)
+      newMethodName: elementNameStrategy
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: org.apache.camel.model.dataformat.SwiftMxDataFormat setReadConfigRef(String)
+      newMethodName: setReadConfig
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: org.apache.camel.model.dataformat.SwiftMxDataFormat.Builder readConfigRef(String)
+      newMethodName: readConfig
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: org.apache.camel.model.dataformat.SwiftMxDataFormat setWriteConfigRef(String)
+      newMethodName: setWriteConfig
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: org.apache.camel.model.dataformat.SwiftMxDataFormat.Builder writeConfigRef(String)
+      newMethodName: writeConfigObject
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: org.apache.camel.model.dataformat.XMLSecurityDataFormat setKeyOrTrustStoreParametersRef(String)
+      newMethodName: setKeyOrTrustStoreParameters
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: org.apache.camel.model.dataformat.XMLSecurityDataFormat.Builder keyOrTrustStoreParametersRef(String)
+      newMethodName: keyOrTrustStoreParameters
+---
+#https://camel.apache.org/manual/camel-4x-upgrade-guide-4_15.html#_data_formats
+type: specs.openrewrite.org/v1beta/recipe
+name: org.apache.camel.upgrade.camel415.yamDataFormats
+displayName: Refactored dataFormats (YAML DSL)
+description: Refactored dataFormats (YAML DSL).
+recipeList:
+  - org.apache.camel.upgrade.customRecipes.ReplacePropertyInDataFormatYaml:
+      component: crypto
+      oldPropertyKey: algorithmParameterRef
+      newPropertyKey: algorithmParameterSpec
+  - org.apache.camel.upgrade.customRecipes.ReplacePropertyInDataFormatYaml:
+      component: crypto
+      oldPropertyKey: keyRef
+      newPropertyKey: key
+  - org.apache.camel.upgrade.customRecipes.ReplacePropertyInDataFormatYaml:
+      component: crypto
+      oldPropertyKey: initVectorRef
+      newPropertyKey: initVector
+  - org.apache.camel.upgrade.customRecipes.ReplacePropertyInDataFormatYaml:
+      component: csv
+      oldPropertyKey: formatRef
+      newPropertyKey: format
+  - org.apache.camel.upgrade.customRecipes.ReplacePropertyInDataFormatYaml:
+      component: csv
+      oldPropertyKey: formatName
+      newPropertyKey: format
+  - org.apache.camel.upgrade.customRecipes.ReplacePropertyInDataFormatYaml:
+      component: flatpack
+      oldPropertyKey: parserFactoryRef
+      newPropertyKey: parserFactory
+  - org.apache.camel.upgrade.customRecipes.ReplacePropertyInDataFormatYaml:
+      component: jaxb
+      oldPropertyKey: namespacePrefixRef
+      newPropertyKey: namespacePrefix
+  - org.apache.camel.upgrade.customRecipes.ReplacePropertyInDataFormatYaml:
+      component: soap
+      oldPropertyKey: namespacePrefixRef
+      newPropertyKey: namespacePrefix
+  - org.apache.camel.upgrade.customRecipes.ReplacePropertyInDataFormatYaml:
+      component: soap
+      oldPropertyKey: elementNameStrategyRef
+      newPropertyKey: elementNameStrategy
+  - org.apache.camel.upgrade.customRecipes.ReplacePropertyInDataFormatYaml:
+      component: swiftMx
+      oldPropertyKey: readConfigRef
+      newPropertyKey: readConfig
+  - org.apache.camel.upgrade.customRecipes.ReplacePropertyInDataFormatYaml:
+      component: swiftMx
+      oldPropertyKey: writeConfigRef
+      newPropertyKey: writeConfig
+  - org.apache.camel.upgrade.customRecipes.ReplacePropertyInDataFormatYaml:
+      component: xmlSecurity
+      oldPropertyKey: keyOrTrustStoreParametersRef
+      newPropertyKey: keyOrTrustStoreParameters
+---
+# https://camel.apache.org/manual/camel-4x-upgrade-guide-4_15.html#_data_formats
+type: specs.openrewrite.org/v1beta/recipe
+name: org.apache.camel.upgrade.camel415.xmlDataFormats
+displayName: Refactored dataFormats (XML DSL)
+description: Refactored dataFormats (XML DSL).
+recipeList:
+  - org.apache.camel.upgrade.customRecipes.ReplacePropertyInDataFormatXml:
+      component: crypto
+      oldPropertyKey: algorithmParameterRef
+      newPropertyKey: algorithmParameterSpec
+  - org.apache.camel.upgrade.customRecipes.ReplacePropertyInDataFormatXml:
+      component: crypto
+      oldPropertyKey: keyRef
+      newPropertyKey: key
+  - org.apache.camel.upgrade.customRecipes.ReplacePropertyInDataFormatXml:
+      component: crypto
+      oldPropertyKey: initVectorRef
+      newPropertyKey: initVector
+  - org.apache.camel.upgrade.customRecipes.ReplacePropertyInDataFormatXml:
+      component: csv
+      oldPropertyKey: formatRef
+      newPropertyKey: format
+  - org.apache.camel.upgrade.customRecipes.ReplacePropertyInDataFormatXml:
+      component: csv
+      oldPropertyKey: formatName
+      newPropertyKey: format
+  - org.apache.camel.upgrade.customRecipes.ReplacePropertyInDataFormatXml:
+      component: flatpack
+      oldPropertyKey: parserFactoryRef
+      newPropertyKey: parserFactory
+  - org.apache.camel.upgrade.customRecipes.ReplacePropertyInDataFormatXml:
+      component: jaxb
+      oldPropertyKey: namespacePrefixRef
+      newPropertyKey: namespacePrefix
+  - org.apache.camel.upgrade.customRecipes.ReplacePropertyInDataFormatXml:
+      component: soap
+      oldPropertyKey: namespacePrefixRef
+      newPropertyKey: namespacePrefix
+  - org.apache.camel.upgrade.customRecipes.ReplacePropertyInDataFormatXml:
+      component: soap
+      oldPropertyKey: elementNameStrategyRef
+      newPropertyKey: elementNameStrategy
+  - org.apache.camel.upgrade.customRecipes.ReplacePropertyInDataFormatXml:
+      component: swiftMx
+      oldPropertyKey: readConfigRef
+      newPropertyKey: readConfig
+  - org.apache.camel.upgrade.customRecipes.ReplacePropertyInDataFormatXml:
+      component: swiftMx
+      oldPropertyKey: writeConfigRef
+      newPropertyKey: writeConfig
+  - org.apache.camel.upgrade.customRecipes.ReplacePropertyInDataFormatXml:
+      component: xmlSecurity
+      oldPropertyKey: keyOrTrustStoreParametersRef
+      newPropertyKey: keyOrTrustStoreParameters
+---
+#https://camel.apache.org/manual/camel-4x-upgrade-guide-4_15.html#_camel_netty_camel_netty_http
+type: specs.openrewrite.org/v1beta/recipe
+name: org.apache.camel.upgrade.camel415.nettyAndNettyHttp
+displayName: Changed parameter in camel-netty and camel-netty-http
+description: Changed parameter in camel-netty and camel-netty-http + enhanced value.
+recipeList:
+# XML
+  - org.apache.camel.upgrade.customRecipes.ReplacePropertyInComponentXml:
+      component: netty
+      oldPropertyKey: keyStoreFile
+      newPropertyKey: keyStoreResource
+      valuePrefix: "file:"
+  - org.apache.camel.upgrade.customRecipes.ReplacePropertyInComponentXml:
+      component: netty
+      oldPropertyKey: trustStoreFile
+      newPropertyKey: trustStoreResource
+      valuePrefix: "file:"
+  - org.apache.camel.upgrade.customRecipes.ReplacePropertyInComponentXml:
+      component: netty-http
+      oldPropertyKey: keyStoreFile
+      newPropertyKey: keyStoreResource
+      valuePrefix: "file:"
+  - org.apache.camel.upgrade.customRecipes.ReplacePropertyInComponentXml:
+      component: netty-http
+      oldPropertyKey: trustStoreFile
+      newPropertyKey: trustStoreResource
+      valuePrefix: "file:"
+# YAML
+  - org.apache.camel.upgrade.customRecipes.ReplacePropertyInComponentYaml:
+      component: netty
+      oldPropertyKey: keyStoreFile
+      newPropertyKey: keyStoreResource
+      valuePrefix: "file:"
+  - org.apache.camel.upgrade.customRecipes.ReplacePropertyInComponentYaml:
+      component: netty
+      oldPropertyKey: trustStoreFile
+      newPropertyKey: trustStoreResource
+      valuePrefix: "file:"
+  - org.apache.camel.upgrade.customRecipes.ReplacePropertyInComponentYaml:
+      component: netty-http
+      oldPropertyKey: keyStoreFile
+      newPropertyKey: keyStoreResource
+      valuePrefix: "file:"
+  - org.apache.camel.upgrade.customRecipes.ReplacePropertyInComponentYaml:
+      component: netty-http
+      oldPropertyKey: trustStoreFile
+      newPropertyKey: trustStoreResource
+      valuePrefix: "file:"

--- a/camel-upgrade-recipes/src/main/resources/META-INF/rewrite/latest.yaml
+++ b/camel-upgrade-recipes/src/main/resources/META-INF/rewrite/latest.yaml
@@ -20,6 +20,7 @@ name: org.apache.camel.upgrade.CamelMigrationRecipe
 displayName: Migrate to @camel-latest-version@
 description: Migrates Apache Camel application to @camel-latest-version@.
 recipeList:
+  - org.apache.camel.upgrade.camel415.CamelMigrationRecipe
   - org.apache.camel.upgrade.camel414.CamelMigrationRecipe
   - org.apache.camel.upgrade.camel413.CamelMigrationRecipe
   - org.apache.camel.upgrade.camel412.CamelMigrationRecipe

--- a/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelTestUtil.java
+++ b/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelTestUtil.java
@@ -49,7 +49,8 @@ public class CamelTestUtil {
         v4_11(4, 11, 0),
         v4_12(4, 12, 0),
         v4_13(4, 13, 0),
-        v4_14(4, 14, 0);
+        v4_14(4, 14, 0),
+        v4_15(4, 15, 0);
 
         private int major;
         private int minor;

--- a/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelUpdate412Test.java
+++ b/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelUpdate412Test.java
@@ -261,6 +261,7 @@ public class CamelUpdate412Test implements RewriteTest {
     @Test
     void yamlDslBearer() {
         //language=yaml
+
         rewriteRun(yaml(
           """
                 - rest:

--- a/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelUpdate415Test.java
+++ b/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelUpdate415Test.java
@@ -1,0 +1,419 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.upgrade;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
+
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.xml.Assertions.xml;
+import static org.openrewrite.yaml.Assertions.yaml;
+
+//class has to stay public, because test is extended in project quarkus-updates
+public class CamelUpdate415Test implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        CamelTestUtil.recipe(spec, CamelTestUtil.CamelVersion.v4_15)
+          .parser(CamelTestUtil.parserFromClasspath(CamelTestUtil.CamelVersion.v4_14, "camel-langchain4j-chat",
+                  "camel-langchain4j-embeddings", "camel-milvus", "camel-neo4j", "camel-pinecone", "camel-qdrant", "camel-weaviate",
+                  "camel-core-model", "camel-spi", "camel-api", "camel-base-engine", "jakarta.xml.bind-api"))
+          .typeValidationOptions(TypeValidation.none());
+    }
+
+    /**
+     * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_15.html#_data_formats">Data Formats</a> in Yaml
+     */
+    @DocumentExample
+    @Test
+    void dataFormatYamlDsl() {
+        //language=yaml
+        rewriteRun(yaml(
+                """
+                       - dataFormats:
+                           crypto:
+                             algorithmParameterRef: "111"
+                             initVectorRef: "222"
+                             keyRef: "333"
+                           csv:
+                             formatRef: "444"
+                             formatName: "555"
+                           flatpack:
+                             parserFactoryRef: "666"
+                           jaxb:
+                              namespacePrefixRef: "777"
+                           soap:
+                              namespacePrefixRef: "888"
+                              elementNameStrategyRef: "999"
+                           swiftMx:
+                               readConfigRef: "1111"
+                               writeConfigRef: "1222"
+                           xmlSecurity:
+                               keyOrTrustStoreParametersRef: "1333"
+                  """,
+                """
+                        - dataFormats:
+                            crypto:
+                              algorithmParameterSpec: "111"
+                              initVector: "222"
+                              key: "333"
+                            csv:
+                              format: "444"
+                              format: "555"
+                            flatpack:
+                              parserFactory: "666"
+                            jaxb:
+                               namespacePrefix: "777"
+                            soap:
+                               namespacePrefix: "888"
+                               elementNameStrategy: "999"
+                            swiftMx:
+                                readConfig: "1111"
+                                writeConfig: "1222"
+                            xmlSecurity:
+                                keyOrTrustStoreParameters: "1333"
+                  """));
+    }
+
+    /**
+     * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_15.html#_camel_ai_nested_headers_classes">Camel AI Nested Headers classes</a>
+     */
+    @Test
+    void aiNestedHeadersTest() {
+        //language=java
+        rewriteRun(java(
+                """
+                  import org.apache.camel.component.langchain4j.chat.LangChain4jChat.Headers;
+                  import org.apache.camel.component.langchain4j.embeddings.LangChain4jEmbeddings.Headers;
+                  import org.apache.camel.component.milvus.Milvus.Headers;
+                  import org.apache.camel.component.neo4j.Neo4jConstants.Headers;
+                  import org.apache.camel.component.qdrant.Qdrant.Headers;
+                  import org.apache.camel.component.pinecone.PineconeVectorDb.Headers;
+                  import org.apache.camel.component.weaviate.WeaviateVectorDb.Headers;
+      
+                  public class AiHeaders{
+                      public void method() {
+                          org.apache.camel.component.langchain4j.chat.LangChain4jChat.Headers h1 = null;
+                          org.apache.camel.component.langchain4j.embeddings.LangChain4jEmbeddings.Headers h2 = null;
+                          org.apache.camel.component.milvus.Milvus.Headers h4 = null;
+                          org.apache.camel.component.neo4j.Neo4jConstants.Headers h5 = null;
+                          org.apache.camel.component.qdrant.Qdrant.Headers h6 = null;
+                          org.apache.camel.component.pinecone.PineconeVectorDb.Headers h7 = null;
+                          org.apache.camel.component.weaviate.WeaviateVectorDb.Headers h8 = null;
+                      }
+                  }
+                  """,
+                """
+                import org.apache.camel.component.langchain4j.chat.LangChain4jChatHeaders;
+                import org.apache.camel.component.langchain4j.embeddings.LangChain4jEmbeddingsHeaders;
+                import org.apache.camel.component.milvus.MilvusHeaders;
+                import org.apache.camel.component.neo4j.Neo4jHeaders;
+                import org.apache.camel.component.qdrant.QdrantHeaders;
+                import org.apache.camel.component.pinecone.PineconeVectorDbHeaders;
+                import org.apache.camel.component.weaviate.WeaviateVectorDbHeaders;
+                
+                public class AiHeaders{
+                    public void method() {
+                        LangChain4jChatHeaders h1 = null;
+                        LangChain4jEmbeddingsHeaders h2 = null;
+                        MilvusHeaders h4 = null;
+                        Neo4jHeaders h5 = null;
+                        QdrantHeaders h6 = null;
+                        PineconeVectorDbHeaders h7 = null;
+                        WeaviateVectorDbHeaders h8 = null;
+                    }
+                }
+                """));
+    }
+
+    /**
+     * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_15.html#_data_formats">Data Formats</a>
+     */
+    @Test
+    void dataformatTest() {
+        //language=java
+        rewriteRun(java(
+                """
+                  import org.apache.camel.model.dataformat.CryptoDataFormat;
+                  import org.apache.camel.model.dataformat.CsvDataFormat;
+                  import org.apache.camel.model.dataformat.FlatpackCsvDataFormat;
+                  import org.apache.camel.model.dataformat.FlatpackDataFormat;
+                  import org.apache.camel.model.dataformat.JaxbDataFormat;
+                  import org.apache.camel.model.dataformat.SoapDataFormat;
+                  import org.apache.camel.model.dataformat.SwiftMxDataFormat;
+                  import org.apache.camel.model.dataformat.XmlSecurityDataFormat;
+      
+                  public class Cr {
+                    public void cryptoDataFormat() {
+                        CryptoDataFormat cfd = new CryptoDataFormat();
+                        cfd.setAlgorithmParameterRef("111");
+                        cfd.setKeyRef("222");
+                        cfd.setInitVectorRef("333");
+
+                        CsvDataFormat csv = new CsvDataFormat();
+                        csv.setFormatRef("444");
+                        csv.setFormatName("555");
+
+                        new FlatpackDataFormat().setParserFactoryRef("666");
+
+                        new JaxbDataFormat().setNamespacePrefixRef("777");
+
+                        SoapDataFormat soap = new SoapDataFormat();;
+
+                        soap.setNamespacePrefixRef("888");
+                        soap.setElementNameStrategyRef("999");
+
+                        SwiftMxDataFormat swift = new SwiftMxDataFormat();
+                        swift.setReadConfigRef("1111");
+                        swift.setWriteConfigRef("1222");
+                        
+//                        new XMLSecurityDataFormat().setKeyOrTrustStoreParametersRef("1333");
+                    }
+                  }
+                  """, //there is missing a reference for proper parsing of XMLSecurityDataFormat
+                """
+
+                  import org.apache.camel.model.dataformat.CryptoDataFormat;
+                  import org.apache.camel.model.dataformat.CsvDataFormat;
+                  import org.apache.camel.model.dataformat.FlatpackCsvDataFormat;
+                  import org.apache.camel.model.dataformat.FlatpackDataFormat;
+                  import org.apache.camel.model.dataformat.JaxbDataFormat;
+                  import org.apache.camel.model.dataformat.SoapDataFormat;
+                  import org.apache.camel.model.dataformat.SwiftMxDataFormat;
+                  import org.apache.camel.model.dataformat.XmlSecurityDataFormat;
+      
+                  public class Cr {
+                    public void cryptoDataFormat() {
+                        CryptoDataFormat cfd = new CryptoDataFormat();
+                        cfd.setAlgorithmParameterSpec("111");
+                        cfd.setKey("222");
+                        cfd.setInitVector("333");
+                        
+                        CsvDataFormat csv = new CsvDataFormat();
+                        csv.setFormat("444");
+                        csv.setFormat("555");
+                        
+                        new FlatpackDataFormat().setParserFactory("666");
+                        
+                        new JaxbDataFormat().setNamespacePrefix("777");
+                        
+                        SoapDataFormat soap = new SoapDataFormat();;
+                      
+                        soap.setNamespacePrefix("888");
+                        soap.setElementNameStrategy("999");
+                        
+                        SwiftMxDataFormat swift = new SwiftMxDataFormat();
+                        swift.setReadConfig("1111");
+                        swift.setWriteConfig("1222");
+                        
+//                        new XMLSecurityDataFormat().setKeyOrTrustStoreParametersRef("1333");
+                    }
+                  }
+                """));
+    }
+
+    /**
+     * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_15.html#_data_formats">Data Formats</a> in Java
+     */
+    @Test
+    void dataformatJavaDSLTest() {
+        //language=java
+        rewriteRun(java(
+                """
+                  import org.apache.camel.builder.RouteBuilder;
+                   
+                  public class MyRoutes extends RouteBuilder {
+                      @Override
+                      public void configure() {
+                          from("direct:format")
+                                  .marshal(dataFormat().crypto().algorithmParameterRef("111").end())
+                                  .marshal(dataFormat().crypto().keyRef("222").end())
+                                  .marshal(dataFormat().crypto().initVectorRef("333").end())
+                                  .marshal(dataFormat().csv().formatName("444").end())
+                                  .marshal(dataFormat().csv().formatRef("555").end())
+                                  .marshal(dataFormat().flatpack().parserFactoryRef("666").end())
+                                  .marshal(dataFormat().jaxb().namespacePrefixRef("777").end())
+                                  .marshal(dataFormat().soap().namespacePrefixRef("888").end())
+                                  .marshal(dataFormat().soap().elementNameStrategyRef("999").end())
+                                  .marshal(dataFormat().swiftMx().readConfigRef("1111").end())
+                                  .marshal(dataFormat().swiftMx().writeConfigRef("1222").end())
+                                  .marshal(dataFormat().xmlSecurity().keyOrTrustStoreParametersRef("1333").end());
+                      }
+                  }
+                  """, //there is missing a reference for proper parsing of XMLSecurityDataFormat
+                """
+                import org.apache.camel.builder.RouteBuilder;
+
+                public class MyRoutes extends RouteBuilder {
+                    @Override
+                    public void configure() {
+                        from("direct:format")
+                                .marshal(dataFormat().crypto().algorithmParameterSpec("111").end())
+                                .marshal(dataFormat().crypto().key("222").end())
+                                .marshal(dataFormat().crypto().initVector("333").end())
+                                .marshal(dataFormat().csv().format("444").end())
+                                .marshal(dataFormat().csv().format("555").end())
+                                .marshal(dataFormat().flatpack().parserFactory("666").end())
+                                .marshal(dataFormat().jaxb().namespacePrefix("777").end())
+                                .marshal(dataFormat().soap().namespacePrefix("888").end())
+                                .marshal(dataFormat().soap().elementNameStrategy("999").end())
+                                .marshal(dataFormat().swiftMx().readConfig("1111").end())
+                                .marshal(dataFormat().swiftMx().writeConfigObject("1222").end())
+                                .marshal(dataFormat().xmlSecurity().keyOrTrustStoreParameters("1333").end());
+                    }
+                }
+                """));
+    }
+
+    /**
+     * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_15.html#_data_formats">Data Formats</a> in DSL
+     */
+    @Test
+    void nettyKeyStoreTestYaml() {
+        //language=yaml
+        rewriteRun(yaml(
+                """
+                      - route:
+                        id: route-3275
+                        from:
+                          id: from-5260
+                          uri: netty
+                          parameters:
+                            host: localhost
+                            keyStoreFile: "/testFile"
+                            trustStoreFile: "/testFile"
+                            port: 12345
+                            protocol: tcp
+                          steps:
+                            id: log-1598
+                            message: ${body}
+                      - route:
+                        id: route-3276
+                        from:
+                          id: from-5261
+                          uri: netty-http
+                          parameters:
+                            host: localhost
+                            keyStoreFile: "/testFile"
+                            trustStoreFile: "/testFile"
+                            port: 12345
+                            protocol: tcp
+                          steps:
+                            id: log-1598
+                            message: ${body}
+                  """,
+                """
+                      - route:
+                        id: route-3275
+                        from:
+                          id: from-5260
+                          uri: netty
+                          parameters:
+                            host: localhost
+                            keyStoreResource: "file:/testFile"
+                            trustStoreResource: "file:/testFile"
+                            port: 12345
+                            protocol: tcp
+                          steps:
+                            id: log-1598
+                            message: ${body}
+                      - route:
+                        id: route-3276
+                        from:
+                          id: from-5261
+                          uri: netty-http
+                          parameters:
+                            host: localhost
+                            keyStoreResource: "file:/testFile"
+                            trustStoreResource: "file:/testFile"
+                            port: 12345
+                            protocol: tcp
+                          steps:
+                            id: log-1598
+                            message: ${body}
+                  """));
+    }
+
+    @Test
+    void xmlDslLoadBalanceFailover() {
+        //language=xml
+        rewriteRun(xml(
+                """
+                  <routes>
+                      <route>
+                          <from uri="netty:tcp:12345?keyStoreFile=some_file"/>
+                          <to uri="mock:result"/>
+                      </route>
+                      <route>
+                          <from uri="netty:tcp:12345?trustStoreFile={{some_file}}"/>
+                          <to uri="mock:result"/>
+                      </route>
+                      <route>
+                          <from uri="netty-http:tcp:12345?anotherAttr=1\\&amp;keyStoreFile='some_file'"/>
+                          <to uri="mock:result"/>
+                      </route>
+                      <route>
+                          <from uri="netty-http:tcp:12345?trustStoreFile={{some_file}}"/>
+                          <to uri="mock:result"/>
+                      </route>
+                      <route>
+                          <from uri="wrong:tcp:12345?trustStoreFile={{some_file}}"/>
+                          <to uri="mock:result"/>
+                      </route>
+                  </routes>
+                  """,
+                """
+                  <routes>
+                      <route>
+                          <from uri="netty:tcp:12345?keyStoreResource=file:some_file"/>
+                          <to uri="mock:result"/>
+                      </route>
+                      <route>
+                          <from uri="netty:tcp:12345?trustStoreResource=file:{{some_file}}"/>
+                          <to uri="mock:result"/>
+                      </route>
+                      <route>
+                          <from uri="netty-http:tcp:12345?anotherAttr=1\\&amp;keyStoreResource=file:'some_file'"/>
+                          <to uri="mock:result"/>
+                      </route>
+                      <route>
+                          <from uri="netty-http:tcp:12345?trustStoreResource=file:{{some_file}}"/>
+                          <to uri="mock:result"/>
+                      </route>
+                      <route>
+                          <from uri="wrong:tcp:12345?trustStoreFile={{some_file}}"/>
+                          <to uri="mock:result"/>
+                      </route>
+                  </routes>
+                  """));
+    }
+
+}
+//<route>
+//                      <from uri="direct:start"/>
+//                      <to uri="crypto:something" algorithmParameterRef='111' initVectorRef='222' keyRef='333'/>
+//                      <to uri="csv" formatRef='444'/>
+//                      <to uri="csv" formatName='555'/>
+//                      <to uri="flatpack" parserFactoryRef='666'/>
+//                      <to uri="jaxb" namespacePrefixRef='777'/>
+//                      <to uri="soap" namespacePrefixRef='888' elementNameStrategyRef='999'/>
+//                      <to uri="swiftMx" readConfigRef='1111' writeConfigRef='1222'/>
+//                      <to uri="xmlSecurity" keyOrTrustStoreParametersRef='1333'/>
+//                    </route>

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,7 @@
         <camel4.9-version>4.9.0</camel4.9-version>
         <camel4.10-version>4.10.0</camel4.10-version>
         <camel4.12-version>4.12.0</camel4.12-version>
+        <camel4.14-version>4.14.0</camel4.14-version>
 
         <camel4.10-lts-version>4.10.6</camel4.10-lts-version>
         <camel-latest-version>4.14.0</camel-latest-version>

--- a/release_notes.adoc
+++ b/release_notes.adoc
@@ -1,5 +1,26 @@
 = Camel Upgrade Recipes - Release notes
 
+== 4.15.0
+
+=== Summary
+
+This is a release supporting Camel and Camel Spring Boot 4.15.0 with the required upgrade recipes (described by the https://camel.apache.org/manual/camel-4x-upgrade-guide-4_15.html[migration guide]).
+
+=== Migration coverage
+
+The following table lists migration topics and indicates the level of coverage (full, partial, or not covered), along with additional comments.
+
+[%autowidth,stripes=hover]
+|===
+| Migration | Coverage | Comment
+
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_15.html#_data_formats[Data Formats] | ⚠️ Partial | DataFormat changes are migrated automatically. Csv's change of parameters from List<String> to String are not supported by the migration tool
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_15.html#_camel_netty_camel_netty_http[camel-netty / camel-netty-htt] | ⚠️ Partial | Basic cases in Xml DSL annd Yaml DSL are covered. Java is not supported by the migration tool, because the java code requires manuall migration due to parameter type change.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_15.html#_camel_ai_nested_headers_classes[Camel AI Nested Headers classes] | ✅ Full |
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_15.html#_camel_mdc[camel-mdc] | ❌ None | Not supported by the migration tool.
+|===
+
+
 == 4.14.0.1
 
 Fixes https://github.com/apache/camel-upgrade-recipes/issues/60


### PR DESCRIPTION
Migration to Camel 4.15.0

@Croway WDYT? there is a migration https://camel.apache.org/manual/camel-4x-upgrade-guide-4_15.html#_camel_netty_camel_netty_http, which addds prefix `file:` to property of the component. I should be able to migrate it automatically, but there might be some rare examples of usa, which might be too complex. (like a user, which sets this property programaticaly in java). Should I cover the base scenarios (java + yaml + xml DSL) and mark it as partially covered by migration tool?

As for CSB I don't think there is anything to take careof. Probably only update of the `latest` recipe