### PR TITLE
Upgrade Camel to 4.16.0

### DIFF
--- a/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/4.16.yaml
+++ b/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/4.16.yaml
@@ -1,0 +1,24 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.apache.camel.upgrade.camel416.CamelSpringBootMigrationRecipe
+displayName: Migrates Camel Spring Boot applications to Camel Spring Boot 4.16
+description: Migrates Camel Spring Boot applications to Camel Spring Boot 4.16.
+recipeList:
+  - org.apache.camel.upgrade.camel415.CamelSpringBootMigrationRecipe
+  - org.apache.camel.upgrade.camel416.CamelMigrationRecipe

--- a/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/latest.yaml
+++ b/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/latest.yaml
@@ -21,6 +21,7 @@ displayName: Migrate to Apache Camel Spring Boot @camel-latest-version@
 description: >- 
   Migrate applications to Apache Camel Spring Boot @camel-latest-version@ and Spring Boot @spring-boot-version@
 recipeList:
+  - org.apache.camel.upgrade.camel416.CamelMigrationRecipe
   - org.apache.camel.upgrade.camel415.CamelMigrationRecipe
   - org.apache.camel.upgrade.camel414.CamelMigrationRecipe
   - org.apache.camel.upgrade.camel413.CamelMigrationRecipe

--- a/camel-upgrade-recipes/pom.xml
+++ b/camel-upgrade-recipes/pom.xml
@@ -232,6 +232,12 @@
                                     <version>${camel3.18-version}</version>
                                     <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
                                 </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.camel</groupId>
+                                    <artifactId>camel-milo</artifactId>
+                                    <version>${camel3.18-version}</version>
+                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
+                                </artifactItem>
 
                                 <!-- camel 4.0 dependencies -->
                                 <artifactItem>
@@ -459,7 +465,7 @@
                                     <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
                                 </artifactItem>
 
-                                <!-- 4.1 -->
+                                <!-- 4.14 -->
                                 <artifactItem>
                                     <groupId>org.apache.camel</groupId>
                                     <artifactId>camel-langchain4j-chat</artifactId>
@@ -552,6 +558,32 @@
                                     <groupId>jakarta.ws.rs</groupId>
                                     <artifactId>jakarta.ws.rs-api</artifactId>
                                     <version>3.1.0</version>
+                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
+                                </artifactItem>
+
+                                <!-- Milo Server -->
+                                <artifactItem>
+                                    <groupId>org.eclipse.milo</groupId>
+                                    <artifactId>stack-core</artifactId>
+                                    <version>0.6.8</version>
+                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.eclipse.milo</groupId>
+                                    <artifactId>stack-server</artifactId>
+                                    <version>0.6.8</version>
+                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.eclipse.milo</groupId>
+                                    <artifactId>stack-client</artifactId>
+                                    <version>0.6.8</version>
+                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.eclipse.milo</groupId>
+                                    <artifactId>sdk-client</artifactId>
+                                    <version>0.6.8</version>
                                     <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
                                 </artifactItem>
 

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/AbstractCamelJavaVisitor.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/AbstractCamelJavaVisitor.java
@@ -123,6 +123,10 @@ public abstract class AbstractCamelJavaVisitor extends JavaIsoVisitor<ExecutionC
         return super.visitLiteral(literal, context);
     }
 
+    protected J.Lambda doVisitLambda(J.Lambda lambda, ExecutionContext context) {
+        return super.visitLambda(lambda, context);
+    }
+
     // ------------------------------------------ helper methods -------------------------------------------
 
     // If the migration fails - do not fail whole migration process, only this one recipe

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel416/Camel416MiloLambdaRecipe.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel416/Camel416MiloLambdaRecipe.java
@@ -1,0 +1,92 @@
+package org.apache.camel.upgrade.camel416;
+
+import lombok.EqualsAndHashCode;
+import lombok.RequiredArgsConstructor;
+import org.apache.camel.upgrade.AbstractCamelJavaVisitor;
+import org.apache.camel.upgrade.RecipesUtil;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.Tree;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.MethodMatcher;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.Space;
+import org.openrewrite.java.tree.VariableDeclarator;
+import org.openrewrite.marker.Markers;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_16.html#_subscription_monitoring_api_changes">Java Milo Subscription API changes</a>
+ */
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
+public class Camel416MiloLambdaRecipe extends Recipe {
+
+    private static final MethodMatcher MATCHER =
+            new MethodMatcher("org.eclipse.milo.opcua.sdk.client.subscriptions.OpcUaMonitoredItem setValueConsumer(java.util.function.Consumer)"); //todo use consumer
+
+    @Override
+    public String getDisplayName() {
+        return "Milo: The monitored item data value listener API has changed";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Milo: The monitored item data value listener API has changed.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return RecipesUtil.newVisitor(new AbstractCamelJavaVisitor() {
+
+           /* todo better solution would be to use templates, but I'm not able to change a lambda parameter in any way
+           private final JavaTemplate template = JavaTemplate.builder(
+                    "#{any(org.eclipse.milo.opcua.sdk.client.subscriptions.OpcUaMonitoredItem)}.setValueConsumer(" +
+                            "(item) -> #{any(org.openrewrite.java.tree.J)};)").build();
+            private final JavaTemplate template2 = JavaTemplate.builder(
+                    "item -> #{any(org.openrewrite.java.tree.J"
+            ).build();
+            */
+
+            @Override
+            public J.MethodInvocation doVisitMethodInvocation(J.MethodInvocation methodInvocation, ExecutionContext ctx) {
+                J.MethodInvocation mi = super.doVisitMethodInvocation(methodInvocation, ctx);
+                //in case the consumer is a lambda function
+                if (MATCHER.matches(mi) && mi.getArguments().get(0) instanceof J.Lambda) {
+                    //add a parameter 'item' into the consumer
+                    J.Lambda l = (J.Lambda) mi.getArguments().get(0);
+                    J.VariableDeclarations existingParam = (J.VariableDeclarations) l.getParameters().getParameters().get(0);
+
+                    //new `item` identifier
+                    VariableDeclarator itemIdentifier = new J.Identifier(Tree.randomId(), Space.EMPTY, Markers.EMPTY, Collections.emptyList(), "item", null, null);
+
+                    //Named Variable is created from `item`
+                    J.VariableDeclarations.NamedVariable itemNamedVariable = new J.VariableDeclarations.NamedVariable(
+                            Tree.randomId(),
+                            Space.EMPTY,
+                            Markers.EMPTY,
+                            itemIdentifier,
+                            Collections.emptyList(),
+                            null,
+                            null
+                    );
+
+                    J.VariableDeclarations newVds = ((J.VariableDeclarations) l.getParameters().getParameters().get(0)).withVariables(Collections.singletonList(itemNamedVariable));
+
+                    //add `item` before original parameter
+                    List<J> newParameters = Arrays.asList(newVds, existingParam);
+                    l = l.withParameters(l.getParameters().withParameters(newParameters).withParenthesized(true));
+
+
+                    //change parameters and method name
+                    mi = mi.withName(mi.getName().withSimpleName("setDataValueListener"));
+                    mi = mi.withArguments(Collections.singletonList(l));
+                }
+                return mi;
+            }
+        });
+    }
+}

--- a/camel-upgrade-recipes/src/main/resources/META-INF/rewrite/4.16.yaml
+++ b/camel-upgrade-recipes/src/main/resources/META-INF/rewrite/4.16.yaml
@@ -1,0 +1,42 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#####
+# Rules coming from https://camel.apache.org/manual/camel-4x-upgrade-guide-4_16.html
+#####
+
+#####
+# Update the Camel project from 4.15 to 4.16
+#####
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.apache.camel.upgrade.camel416.CamelMigrationRecipe
+displayName: Migrates `camel 4.15` application to `camel 4.16`
+description: Migrates `camel 4.15` application to `camel 4.16`.
+recipeList:
+  - org.apache.camel.upgrade.camel416.Camel416MiloLambdaRecipe
+  - org.apache.camel.upgrade.camel416.camelMiloCertificate
+---
+#https://camel.apache.org/manual/camel-4x-upgrade-guide-4_16.html#_certificate_validation_api_changes
+type: specs.openrewrite.org/v1beta/recipe
+name: org.apache.camel.upgrade.camel416.camelMiloCertificate
+displayName: Different java type for ServerCertificateValidator in camel-milo
+description: Different java type for ServerCertificateValidator in camel-milo.
+recipeList:
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.eclipse.milo.opcua.stack.server.security.ServerCertificateValidator
+      newFullyQualifiedTypeName: org.eclipse.milo.opcua.stack.core.security.CertificateValidator

--- a/camel-upgrade-recipes/src/main/resources/META-INF/rewrite/latest.yaml
+++ b/camel-upgrade-recipes/src/main/resources/META-INF/rewrite/latest.yaml
@@ -20,6 +20,7 @@ name: org.apache.camel.upgrade.CamelMigrationRecipe
 displayName: Migrate to @camel-latest-version@
 description: Migrates Apache Camel application to @camel-latest-version@.
 recipeList:
+  - org.apache.camel.upgrade.camel416.CamelMigrationRecipe
   - org.apache.camel.upgrade.camel415.CamelMigrationRecipe
   - org.apache.camel.upgrade.camel414.CamelMigrationRecipe
   - org.apache.camel.upgrade.camel413.CamelMigrationRecipe

--- a/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelTestUtil.java
+++ b/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelTestUtil.java
@@ -50,7 +50,8 @@ public class CamelTestUtil {
         v4_12(4, 12, 0),
         v4_13(4, 13, 0),
         v4_14(4, 14, 0),
-        v4_15(4, 15, 0);
+        v4_15(4, 15, 0),
+        v4_16(4, 16, 0);
 
         private int major;
         private int minor;

--- a/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelUpdate416From3xTest.java
+++ b/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelUpdate416From3xTest.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.upgrade;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
+
+import static org.openrewrite.java.Assertions.java;
+
+//class has to stay public, because test is extended in project quarkus-updates
+public class CamelUpdate416From3xTest implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        CamelTestUtil.recipe(spec, CamelTestUtil.CamelVersion.v4_16)
+                .parser(CamelTestUtil.parserFromClasspath(CamelTestUtil.CamelVersion.v3_18,
+                        "camel-milo", "stack-server-0.6.8", "stack-client-0.6.8", "stack-core-0.6.8", "sdk-client-0.6.8"))
+                .typeValidationOptions(TypeValidation.none());
+    }
+
+    /**
+     * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_16.html#_certificate_validation_api_changes">camel-milo API changes</a>
+     */
+    @DocumentExample
+    @Test
+    void miloApiChange() {
+        //language=java
+        rewriteRun(java(
+                """
+                  import org.apache.camel.component.milo.server.MiloServerComponent;
+                  import org.eclipse.milo.opcua.stack.server.security.ServerCertificateValidator;
+                  import org.eclipse.milo.opcua.stack.server.security.DefaultServerCertificateValidator;
+                  
+                  public class MiloTest {
+                  
+                      public void test()  {
+                          MiloServerComponent server = null;
+                          ServerCertificateValidator scv = new DefaultServerCertificateValidator(null);
+                          server.setCertificateValidator(scv);
+                      }
+                  }
+                  """,
+                """
+                  import org.apache.camel.component.milo.server.MiloServerComponent;
+                  import org.eclipse.milo.opcua.stack.core.security.CertificateValidator;
+                  import org.eclipse.milo.opcua.stack.server.security.DefaultServerCertificateValidator;
+                  
+                  public class MiloTest {
+                  
+                      public void test()  {
+                          MiloServerComponent server = null;
+                          CertificateValidator scv = new DefaultServerCertificateValidator(null);
+                          server.setCertificateValidator(scv);
+                      }
+                  }
+                  """));
+    }
+
+    /**
+     * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_16.html#_subscription_monitoring_api_changes">camel-milo subscription monitoring API changes</a>
+     */
+    @Test
+    void miloSubscriptionMonitoringApiChanges() {
+        //language=java
+        rewriteRun(java(
+                """
+                  import org.apache.camel.component.milo.server.MiloServerComponent;
+                  import org.eclipse.milo.opcua.sdk.client.subscriptions.OpcUaMonitoredItem;
+                  
+                  public class MiloTest {
+                  
+                      public void test()  {
+                          OpcUaMonitoredItem item = null;
+                          item.setValueConsumer(dataValue -> {int i = 0;});
+                      }
+                  }
+                  """,
+                """
+                  import org.apache.camel.component.milo.server.MiloServerComponent;
+                  import org.eclipse.milo.opcua.sdk.client.subscriptions.OpcUaMonitoredItem;
+                  
+                  public class MiloTest {
+                  
+                      public void test()  {
+                          OpcUaMonitoredItem item = null;
+                          item.setDataValueListener((item,dataValue) -> {int i = 0;});
+                      }
+                  }
+                  """));
+    }
+
+
+}

--- a/release_notes.adoc
+++ b/release_notes.adoc
@@ -1,5 +1,29 @@
 = Camel Upgrade Recipes - Release notes
 
+== 4.16.0
+
+=== Summary
+
+This is a release supporting Camel and Camel Spring Boot 4.16.0 with the required upgrade recipes (described by the https://camel.apache.org/manual/camel-4x-upgrade-guide-4_16.html[migration guide]).
+
+=== Migration coverage
+
+The following table lists migration topics and indicates the level of coverage (full, partial, or not covered), along with additional comments.
+
+[%autowidth,stripes=hover]
+|===
+| Migration | Coverage | Comment
+
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_16.html#_eips[EIPS] | ❌ None | Not supported by the migration tool.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_16.html#_camel_core[camel-core] | ❌ None | Not supported by the migration tool.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_16.html#_camel_as2[camel-as2] | ❌ None | Not supported by the migration tool.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_16.html#_camel_kamelet[camel-kamelet] | ❌ None | Not supported by the migration tool.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_16.html#_camel_infinispan[camel-infinispan] | ❌ None | Not supported by the migration tool.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_16.html#_camel_jbang[camel-jbang] | ❌ None | Not supported by the migration tool.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_16.html#_camel_milo[camel-milo] | ⚠️ Partial | Certificate validation API changes are covered. Subscription monitoring API changes are covered only if lambda expression is used.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_16.html#_camel_flink[camel-flink] | ❌ None | Not supported by the migration tool.
+|===
+
 == 4.15.0
 
 === Summary


### PR DESCRIPTION
Upgrade camel to 4.16.0.

I realized, that the migration of camel-milo belongs here, even if camel-milo was removed in 3.9.0. (Because the recipes covers upgrade from 3.x to 4.0)