### PR TITLE
Migrate Camel 4.17 to 4.18

### DIFF
--- a/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/4.18.yaml
+++ b/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/4.18.yaml
@@ -1,0 +1,24 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.apache.camel.upgrade.camel418.CamelSpringBootMigrationRecipe
+displayName: Migrates Camel Spring Boot applications to Camel Spring Boot 4.18
+description: Migrates Camel Spring Boot applications to Camel Spring Boot 4.18.
+recipeList:
+  - org.apache.camel.upgrade.camel417.CamelSpringBootMigrationRecipe
+  - org.apache.camel.upgrade.camel418.CamelMigrationRecipe

--- a/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/latest.yaml
+++ b/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/latest.yaml
@@ -21,6 +21,7 @@ displayName: Migrate to Apache Camel Spring Boot @camel-latest-version@
 description: >- 
   Migrate applications to Apache Camel Spring Boot @camel-latest-version@ and Spring Boot @spring-boot-version@
 recipeList:
+  - org.apache.camel.upgrade.camel418.CamelMigrationRecipe
   - org.apache.camel.upgrade.camel417.CamelMigrationRecipe
   - org.apache.camel.upgrade.camel416.CamelMigrationRecipe
   - org.apache.camel.upgrade.camel415.CamelMigrationRecipe

--- a/camel-upgrade-recipes/pom.xml
+++ b/camel-upgrade-recipes/pom.xml
@@ -509,6 +509,26 @@
                                     <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
                                 </artifactItem>
 
+                                <!-- 4.17 -->
+                                <artifactItem>
+                                    <groupId>org.apache.camel</groupId>
+                                    <artifactId>camel-qdrant</artifactId>
+                                    <version>${camel4.17-version}</version>
+                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.apache.camel</groupId>
+                                    <artifactId>camel-tahu</artifactId>
+                                    <version>${camel4.17-version}</version>
+                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
+                                </artifactItem>
+                                <dependency>
+                                    <groupId>org.eclipse.tahu</groupId>
+                                    <artifactId>tahu-host</artifactId>
+                                    <version>${tahu-version}</version>
+                                    <outputDirectory>${rewrite-tmp-classpath}</outputDirectory>
+                                </dependency>
+
                                 <!-- Apache HTTP Client -->
                                 <artifactItem>
                                     <groupId>org.apache.httpcomponents</groupId>

--- a/camel-upgrade-recipes/src/main/resources/META-INF/rewrite/4.18.yaml
+++ b/camel-upgrade-recipes/src/main/resources/META-INF/rewrite/4.18.yaml
@@ -1,0 +1,39 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#####
+# Rules coming from https://camel.apache.org/manual/camel-4x-upgrade-guide-4_18.html
+#####
+
+#####
+# Update the Camel project from 4.17 to 4.18
+#####
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.apache.camel.upgrade.camel418.CamelMigrationRecipe
+displayName: Migrates `camel 4.17` application to `camel 4.18`
+description: Migrates `camel 4.17` application to `camel 4.18`.
+recipeList:
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.qdrant.Qdrant.Headers
+      newFullyQualifiedTypeName: org.apache.camel.component.qdrant.QdrantHeaders
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.apache.camel.component.tahu.handlers.TahuHostApplicationEventHandler
+      newFullyQualifiedTypeName: org.apache.camel.component.tahu.handlers.MultiTahuHostApplicationEventHandler
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.eclipse.tahu.host.api.HostApplicationEventHandler
+      newFullyQualifiedTypeName: org.eclipse.tahu.host.api.MultiHostApplicationEventHandler

--- a/camel-upgrade-recipes/src/main/resources/META-INF/rewrite/latest.yaml
+++ b/camel-upgrade-recipes/src/main/resources/META-INF/rewrite/latest.yaml
@@ -20,6 +20,7 @@ name: org.apache.camel.upgrade.CamelMigrationRecipe
 displayName: Migrate to @camel-latest-version@
 description: Migrates Apache Camel application to @camel-latest-version@.
 recipeList:
+  - org.apache.camel.upgrade.camel418.CamelMigrationRecipe
   - org.apache.camel.upgrade.camel417.CamelMigrationRecipe
   - org.apache.camel.upgrade.camel416.CamelMigrationRecipe
   - org.apache.camel.upgrade.camel415.CamelMigrationRecipe

--- a/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelTestUtil.java
+++ b/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelTestUtil.java
@@ -52,7 +52,8 @@ public class CamelTestUtil {
         v4_14(4, 14, 0),
         v4_15(4, 15, 0),
         v4_16(4, 16, 0),
-        v4_17(4, 17, 0);
+        v4_17(4, 17, 0),
+        v4_18(4, 18, 0);
 
         private int major;
         private int minor;

--- a/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelUpdate418Test.java
+++ b/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelUpdate418Test.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.upgrade;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
+
+import static org.openrewrite.java.Assertions.java;
+
+//class has to stay public, because test is extended in project quarkus-updates
+public class CamelUpdate418Test implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        CamelTestUtil.recipe(spec, CamelTestUtil.CamelVersion.v4_18)
+                .parser(CamelTestUtil.parserFromClasspath(CamelTestUtil.CamelVersion.v4_17,
+                        "camel-core-model", "camel-api", "camel-qdrant", "camel-tahu", "tahu-host"))
+                .typeValidationOptions(TypeValidation.none());
+    }
+
+    /**
+     * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_18.html#_camel_qdrant">camel-qdrant changes</a>
+     */
+    @DocumentExample
+    @Test
+    void qdrantHeadersChange() {
+        //language=java
+        rewriteRun(java(
+                """
+                  import org.apache.camel.component.qdrant.Qdrant.Headers;
+
+                  public class QdrantTest {
+
+                      public void test()  {
+                          Headers headers = null;
+                      }
+                  }
+                  """,
+                """
+                  import org.apache.camel.component.qdrant.QdrantHeaders;
+
+                  public class QdrantTest {
+
+                      public void test()  {
+                          QdrantHeaders headers = null;
+                      }
+                  }
+                  """));
+    }
+
+    /**
+     * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_18.html#_camel_tahu">camel-tahu changes</a>
+     */
+    @Test
+    void tahuChange() {
+        //language=java
+        rewriteRun(java(
+                """
+                  import org.apache.camel.component.tahu.handlers.TahuHostApplicationEventHandler;
+                  import org.eclipse.tahu.host.api.HostApplicationEventHandler;
+                  
+                  public class TahuTest {
+                  
+                      public void test()  {
+                          HostApplicationEventHandler h1 = null;
+                          TahuHostApplicationEventHandler h2 = null;
+                      }
+                  }
+                  """,
+                """
+                  import org.apache.camel.component.tahu.handlers.MultiTahuHostApplicationEventHandler;
+                  import org.eclipse.tahu.host.api.MultiHostApplicationEventHandler;
+                  
+                  public class TahuTest {
+                  
+                      public void test()  {
+                          MultiHostApplicationEventHandler h1 = null;
+                          MultiTahuHostApplicationEventHandler h2 = null;
+                      }
+                  }
+                  """));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -102,12 +102,16 @@
         <camel4.10-version>4.10.0</camel4.10-version>
         <camel4.12-version>4.12.0</camel4.12-version>
         <camel4.14-version>4.14.0</camel4.14-version>
+        <camel4.17-version>4.17.0</camel4.17-version>
 
         <camel4.10-lts-version>4.10.6</camel4.10-lts-version>
         <camel-latest-version>4.14.0</camel-latest-version>
 
         <camel-version>${project.version}</camel-version>
         <camel-spring-boot-version>${project.version}</camel-spring-boot-version>
+
+        <!-- other versions used by the tests -->
+        <tahu-version>1.0.18</tahu-version>
 
         <!-- versions for camel-spring-boot -->
         <spring-boot-version>3.5.6</spring-boot-version>

--- a/release_notes.adoc
+++ b/release_notes.adoc
@@ -1,5 +1,27 @@
 = Camel Upgrade Recipes - Release notes
 
+== 4.18.0
+
+=== Summary
+
+This is a release supporting Camel, Camel Quarkus and Camel Spring Boot 4.18.0 with the required upgrade recipes (described by the https://camel.apache.org/manual/camel-4x-upgrade-guide-4_17.html[migration guide]).
+
+=== Migration coverage
+
+The following table lists migration topics and indicates the level of coverage (full, partial, or not covered), along with additional comments.
+
+[%autowidth,stripes=hover]
+|===
+| Migration | Coverage | Comment
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_18.html#_camel_simple[camel-simple] |  ❌ None | Not supported by the migration tool.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_18.html#_camel_file[camel-file] | ❌ None | Not supported by the migration tool.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_18.html#_camel_docling[camel-docling] | ❌ None | Not supported by the migration tool.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_18.html#_camel_qdrant[camel-qdrant] | ✅ Full todo    | Automatically migrated.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_18.html#_camel_tahu[camel-tahu] | ⚠️ Partial | Tool renames handlers to MultiHostApplicationEventHandler. Other API changes are not covered.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_18.html#_camel_platform_http_vertx_and_rest_dsl_contract_first[camel-platform-http-vertx and Rest DSL contract-first] | ❌ None | Not supported by the migration tool.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_18.html#_component_deprecation[Component deprecation] | ❌ None | Not supported by the migration tool.
+|===
+
 == 4.17.0
 
 === Summary


### PR DESCRIPTION
Migrate Camel 4.17 to 4.18
https://camel.apache.org/manual/camel-4x-upgrade-guide-4_18.html