### PR TITLE
Upgrade to camel 4.19

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ target
 .classpath
 .ekstazi
 .project
+.versionsBackup
 .settings
 .checkstyle
 *.log

--- a/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/4.19.yaml
+++ b/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/4.19.yaml
@@ -1,0 +1,90 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.apache.camel.upgrade.camel419.CamelSpringBootMigrationRecipe
+displayName: Migrates Camel Spring Boot applications to Camel Spring Boot 4.19
+description: Migrates Camel Spring Boot applications to Camel Spring Boot 4.19.
+recipeList:
+  - org.apache.camel.upgrade.camel419.CamelMigrationRecipe
+  - org.apache.camel.upgrade.camel419.migrateJUnitStarterDependency
+  - org.apache.camel.upgrade.camel419.upgradeSpringFrameworkDependencies
+  - org.apache.camel.upgrade.camel419.migrateMdcLoggingSpringBoot
+  - org.apache.camel.upgrade.camel419.migrateGroovyXmlStarter
+  - org.openrewrite.java.testing.junit5.JUnit5BestPractices
+  - org.openrewrite.java.testing.junit5.UpgradeJUnit5_6
+---
+# Migrate Spring Boot JUnit 5 starter to JUnit 6
+type: specs.openrewrite.org/v1beta/recipe
+name: org.apache.camel.upgrade.camel419.migrateJUnitStarterDependency
+displayName: Migrate camel-test-spring-junit5 to camel-test-spring-junit6
+description: Migrates camel-test-spring-junit5 to camel-test-spring-junit6 and updates Camel test package imports.
+recipeList:
+  - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
+      oldGroupId: org.apache.camel
+      oldArtifactId: camel-test-spring-junit5
+      newGroupId: org.apache.camel
+      newArtifactId: camel-test-spring-junit6
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.apache.camel.test.spring.junit5
+      newPackageName: org.apache.camel.test.spring.junit6
+      recursive: true
+---
+# Upgrade Spring Framework dependencies using custom recipes
+type: specs.openrewrite.org/v1beta/recipe
+name: org.apache.camel.upgrade.camel419.upgradeSpringFrameworkDependencies
+displayName: Upgrade Spring Framework dependencies for Camel 4.19
+description: Upgrades Spring Boot to 4.x, Spring Framework to 7.x, Spring Security to 7.x, and Spring Batch to 6.x using custom recipes.
+recipeList:
+  # Upgrade Spring Boot 3 to 4
+  - org.apache.camel.upgrade.spring.UpgradeSpringBoot3To4
+  # Upgrade Spring Framework 6 to 7
+  - org.apache.camel.upgrade.spring.UpgradeSpringFramework6To7
+  # Upgrade Spring Security 6 to 7
+  - org.apache.camel.upgrade.spring.UpgradeSpringSecurity6To7
+  # Upgrade Spring Batch 5 to 6
+  - org.apache.camel.upgrade.spring.UpgradeSpringBatch5To6
+---
+# https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_mdc_older_logic_deprecation
+# Migrate from deprecated useMdcLogging property to camel-mdc-starter for Spring Boot
+type: specs.openrewrite.org/v1beta/recipe
+name: org.apache.camel.upgrade.camel419.migrateMdcLoggingSpringBoot
+displayName: Migrate from deprecated MDC logging property to camel-mdc-starter
+description: The older logic used for MDC (enabled via camel.main.useMdcLogging = true) is deprecated in favor of camel-mdc component. This recipe adds the camel-mdc-starter dependency and removes the deprecated property.
+recipeList:
+  - org.openrewrite.maven.AddDependency:
+      groupId: org.apache.camel.springboot
+      artifactId: camel-mdc-starter
+      version: ${camel.version}
+      acceptTransitive: true
+  - org.openrewrite.properties.DeleteProperty:
+      propertyKey: camel.main.useMdcLogging
+  - org.openrewrite.yaml.DeleteProperty:
+      propertyKey: $.camel.main.useMdcLogging
+---
+# https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_groovy_xml
+# Migrate camel-groovy-xml-starter to camel-groovy-starter
+type: specs.openrewrite.org/v1beta/recipe
+name: org.apache.camel.upgrade.camel419.migrateGroovyXmlStarter
+displayName: Migrate camel-groovy-xml-starter to camel-groovy-starter
+description: camel-groovy-xml has been removed and moved into camel-groovy. Changes the dependency from camel-groovy-xml-starter to camel-groovy-starter.
+recipeList:
+  - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
+      oldGroupId: org.apache.camel.springboot
+      oldArtifactId: camel-groovy-xml-starter
+      newGroupId: org.apache.camel.springboot
+      newArtifactId: camel-groovy-starter

--- a/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/4.19.yaml
+++ b/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/4.19.yaml
@@ -20,20 +20,84 @@ name: org.apache.camel.upgrade.camel419.CamelSpringBootMigrationRecipe
 displayName: Migrates Camel Spring Boot applications to Camel Spring Boot 4.19
 description: Migrates Camel Spring Boot applications to Camel Spring Boot 4.19.
 recipeList:
+  # Upgrade versions FIRST before adding new 4.19 dependencies
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: 'org.apache.camel'
+      artifactId: '*'
+      newVersion: @camel-latest-version@
+  - org.openrewrite.maven.UpgradePluginVersion:
+      groupId: 'org.apache.camel'
+      artifactId: '*'
+      newVersion: @camel-latest-version@
+  - org.openrewrite.maven.UpgradeParentVersion:
+      groupId: 'org.apache.camel'
+      artifactId: '*'
+      newVersion: @camel-latest-version@
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: camel.version
+      newValue: @camel-latest-version@
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: '*camel*'
+      artifactId: 'camel-spring-boot-bom'
+      newVersion: @camel-spring-boot-version@
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: 'org.apache.camel.springboot'
+      artifactId: '*'
+      newVersion: @camel-spring-boot-version@
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: camel-spring-boot.version
+      newValue: @camel-spring-boot-version@
+  # Now run API migrations that may add new dependencies
   - org.apache.camel.upgrade.camel419.CamelMigrationRecipe
-  - org.apache.camel.upgrade.camel419.migrateJUnitStarterDependency
+  - org.apache.camel.upgrade.camel419.upgradeJUnit5To6
   - org.apache.camel.upgrade.camel419.upgradeSpringFrameworkDependencies
   - org.apache.camel.upgrade.camel419.migrateMdcLoggingSpringBoot
   - org.apache.camel.upgrade.camel419.migrateGroovyXmlStarter
-  - org.openrewrite.java.testing.junit5.JUnit5BestPractices
-  - org.openrewrite.java.testing.junit5.UpgradeJUnit5_6
 ---
-# Migrate Spring Boot JUnit 5 starter to JUnit 6
+# Upgrade JUnit 5 to JUnit 6 for Camel
 type: specs.openrewrite.org/v1beta/recipe
-name: org.apache.camel.upgrade.camel419.migrateJUnitStarterDependency
-displayName: Migrate camel-test-spring-junit5 to camel-test-spring-junit6
-description: Migrates camel-test-spring-junit5 to camel-test-spring-junit6 and updates Camel test package imports.
+name: org.apache.camel.upgrade.camel419.upgradeJUnit5To6
+displayName: Upgrade JUnit 5 to JUnit 6
+description: Migrates JUnit 5 to JUnit 6.0.3 and updates all Camel test dependencies from junit5 to junit6.
 recipeList:
+  # Upgrade core JUnit dependencies
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: org.junit.jupiter
+      artifactId: junit-jupiter
+      newVersion: 6.0.3
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: org.junit.jupiter
+      artifactId: junit-jupiter-api
+      newVersion: 6.0.3
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: org.junit.jupiter
+      artifactId: junit-jupiter-engine
+      newVersion: 6.0.3
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: org.junit.jupiter
+      artifactId: junit-jupiter-params
+      newVersion: 6.0.3
+  # Migrate camel-test-junit5 to camel-test-junit6
+  - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
+      oldGroupId: org.apache.camel
+      oldArtifactId: camel-test-junit5
+      newGroupId: org.apache.camel
+      newArtifactId: camel-test-junit6
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.apache.camel.test.junit5
+      newPackageName: org.apache.camel.test.junit6
+      recursive: true
+  # Migrate camel-test-main-junit5 to camel-test-main-junit6
+  - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
+      oldGroupId: org.apache.camel
+      oldArtifactId: camel-test-main-junit5
+      newGroupId: org.apache.camel
+      newArtifactId: camel-test-main-junit6
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.apache.camel.test.main.junit5
+      newPackageName: org.apache.camel.test.main.junit6
+      recursive: true
+  # Migrate camel-test-spring-junit5 to camel-test-spring-junit6
   - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
       oldGroupId: org.apache.camel
       oldArtifactId: camel-test-spring-junit5
@@ -63,14 +127,9 @@ recipeList:
 # Migrate from deprecated useMdcLogging property to camel-mdc-starter for Spring Boot
 type: specs.openrewrite.org/v1beta/recipe
 name: org.apache.camel.upgrade.camel419.migrateMdcLoggingSpringBoot
-displayName: Migrate from deprecated MDC logging property to camel-mdc-starter
-description: The older logic used for MDC (enabled via camel.main.useMdcLogging = true) is deprecated in favor of camel-mdc component. This recipe adds the camel-mdc-starter dependency and removes the deprecated property.
+displayName: Remove deprecated MDC logging property
+description: The older logic used for MDC (enabled via camel.main.useMdcLogging = true) is deprecated in favor of camel-mdc component. This recipe removes the deprecated property. If you were using MDC logging, manually add the camel-mdc-starter dependency.
 recipeList:
-  - org.openrewrite.maven.AddDependency:
-      groupId: org.apache.camel.springboot
-      artifactId: camel-mdc-starter
-      version: ${camel.version}
-      acceptTransitive: true
   - org.openrewrite.properties.DeleteProperty:
       propertyKey: camel.main.useMdcLogging
   - org.openrewrite.yaml.DeleteProperty:

--- a/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/4.19.yaml
+++ b/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/4.19.yaml
@@ -49,6 +49,7 @@ recipeList:
       newValue: @camel-spring-boot-version@
   # Now run API migrations that may add new dependencies
   - org.apache.camel.upgrade.camel419.CamelMigrationRecipe
+  - org.apache.camel.upgrade.camel418.CamelSpringBootMigrationRecipe
   - org.apache.camel.upgrade.camel419.upgradeJUnit5To6
   - org.apache.camel.upgrade.camel419.upgradeSpringFrameworkDependencies
   - org.apache.camel.upgrade.camel419.migrateMdcLoggingSpringBoot

--- a/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/latest.yaml
+++ b/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/latest.yaml
@@ -21,6 +21,8 @@ displayName: Migrate to Apache Camel Spring Boot @camel-latest-version@
 description: >- 
   Migrate applications to Apache Camel Spring Boot @camel-latest-version@ and Spring Boot @spring-boot-version@
 recipeList:
+  - org.apache.camel.upgrade.camel419.CamelSpringBootMigrationRecipe
+  - org.apache.camel.upgrade.camel419.CamelMigrationRecipe
   - org.apache.camel.upgrade.camel418.CamelMigrationRecipe
   - org.apache.camel.upgrade.camel417.CamelMigrationRecipe
   - org.apache.camel.upgrade.camel416.CamelMigrationRecipe

--- a/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/latest.yaml
+++ b/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/latest.yaml
@@ -22,25 +22,6 @@ description: >-
   Migrate applications to Apache Camel Spring Boot @camel-latest-version@ and Spring Boot @spring-boot-version@
 recipeList:
   - org.apache.camel.upgrade.camel419.CamelSpringBootMigrationRecipe
-  - org.apache.camel.upgrade.camel419.CamelMigrationRecipe
-  - org.apache.camel.upgrade.camel418.CamelMigrationRecipe
-  - org.apache.camel.upgrade.camel417.CamelMigrationRecipe
-  - org.apache.camel.upgrade.camel416.CamelMigrationRecipe
-  - org.apache.camel.upgrade.camel415.CamelMigrationRecipe
-  - org.apache.camel.upgrade.camel414.CamelMigrationRecipe
-  - org.apache.camel.upgrade.camel413.CamelMigrationRecipe
-  - org.apache.camel.upgrade.camel412.CamelMigrationRecipe
-  - org.apache.camel.upgrade.camel411.CamelMigrationRecipe
-  - org.apache.camel.upgrade.camel410.CamelMigrationRecipe
-  - org.apache.camel.upgrade.camel49.CamelMigrationRecipe
-  - org.apache.camel.upgrade.camel47.CamelMigrationRecipe
-  - org.apache.camel.upgrade.camel46.CamelMigrationRecipe
-  - org.apache.camel.upgrade.camel45.CamelMigrationRecipe
-  - org.apache.camel.upgrade.camel44.CamelMigrationRecipe
-  - org.apache.camel.upgrade.camel40.CamelMigrationRecipe
-  - org.apache.camel.upgrade.UpgradeToJava17
-  - org.apache.camel.upgrade.JavaVersion17
-  - org.apache.camel.upgrade.UpdateCamelSpringBootPropertiesAndYamlKeys
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: '*camel*'
       artifactId: 'camel-spring-boot-bom'
@@ -74,22 +55,3 @@ recipeList:
       groupId: org.springframework.boot
       artifactId: spring-boot-starter-parent
       newVersion: @spring-boot-version@
-  - org.openrewrite.maven.RemoveDependency:
-       groupId: org.apache.camel.springboot
-       artifactId: camel-k-starter
-  - org.openrewrite.maven.RemoveDependency:
-        groupId: org.apache.camel.springboot
-        artifactId: camel-etcd3-starter
-  - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
-      oldGroupId: org.apache.camel-springboot
-      oldArtifactId: camel-fury-starter
-      newArtifactId: camel-fory-starter
-  - org.apache.camel.upgrade.customRecipes.PropertiesAndYamlKeyUpdate:
-      oldPropertyKey: camel.springboot.main-run-controller
-      newPropertyKey: camel.main.run-controller
-  - org.apache.camel.upgrade.customRecipes.PropertiesAndYamlKeyUpdate:
-      oldPropertyKey: camel.springboot.include-non-singletons
-      newPropertyKey: camel.main.include-non-singletons
-  - org.apache.camel.upgrade.customRecipes.PropertiesAndYamlKeyUpdate:
-      oldPropertyKey: camel.springboot.warn-on-early-shutdown
-      newPropertyKey: camel.main.warn-on-early-shutdown

--- a/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/spring-batch-5-to-6.yaml
+++ b/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/spring-batch-5-to-6.yaml
@@ -1,0 +1,217 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+# Upgrade Spring Batch from 5.* to 6.*
+# See: https://github.com/spring-projects/spring-batch/wiki/Spring-Batch-6.0-Migration-Guide
+type: specs.openrewrite.org/v1beta/recipe
+name: org.apache.camel.upgrade.spring.UpgradeSpringBatch5To6
+displayName: Upgrade Spring Batch from 5.* to 6.*
+description: Upgrades Spring Batch dependencies from 5.* to 6.* and migrates moved/renamed APIs.
+recipeList:
+  # Update Spring Batch version property
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: spring-batch.version
+      newValue: ${spring-batch-version}
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: spring-batch-version
+      newValue: ${spring-batch-version}
+  # Update Spring Batch dependencies
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: org.springframework.batch
+      artifactId: "*"
+      newVersion: ${spring-batch-version}
+  # Migrate moved and renamed APIs
+  - org.apache.camel.upgrade.spring.SpringBatch6MovedAPIs
+  - org.apache.camel.upgrade.spring.SpringBatch6RenamedAPIs
+---
+# Migrate moved APIs in Spring Batch 6.*
+# See: https://github.com/spring-projects/spring-batch/wiki/Spring-Batch-6.0-Migration-Guide#moved-apis
+type: specs.openrewrite.org/v1beta/recipe
+name: org.apache.camel.upgrade.spring.SpringBatch6MovedAPIs
+displayName: Migrate Spring Batch 6.* moved APIs
+description: Migrates packages and types that were moved in Spring Batch 6.*.
+recipeList:
+  # Move explore package
+  - org.openrewrite.java.ChangePackage:
+      oldPackageName: org.springframework.batch.core.explore
+      newPackageName: org.springframework.batch.core.repository.explore
+      recursive: true
+  # Move JDBC DAO classes
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.repository.dao.JdbcExecutionContextDao
+      newFullyQualifiedTypeName: org.springframework.batch.core.repository.dao.jdbc.JdbcExecutionContextDao
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.repository.dao.JdbcJobExecutionDao
+      newFullyQualifiedTypeName: org.springframework.batch.core.repository.dao.jdbc.JdbcJobExecutionDao
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.repository.dao.JdbcJobInstanceDao
+      newFullyQualifiedTypeName: org.springframework.batch.core.repository.dao.jdbc.JdbcJobInstanceDao
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.repository.dao.JdbcStepExecutionDao
+      newFullyQualifiedTypeName: org.springframework.batch.core.repository.dao.jdbc.JdbcStepExecutionDao
+  # Move Mongo DAO classes
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.repository.dao.MongoExecutionContextDao
+      newFullyQualifiedTypeName: org.springframework.batch.core.repository.dao.mongo.MongoExecutionContextDao
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.repository.dao.MongoJobExecutionDao
+      newFullyQualifiedTypeName: org.springframework.batch.core.repository.dao.mongo.MongoJobExecutionDao
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.repository.dao.MongoJobInstanceDao
+      newFullyQualifiedTypeName: org.springframework.batch.core.repository.dao.mongo.MongoJobInstanceDao
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.repository.dao.MongoStepExecutionDao
+      newFullyQualifiedTypeName: org.springframework.batch.core.repository.dao.mongo.MongoStepExecutionDao
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.repository.dao.MongoSequenceIncrementer
+      newFullyQualifiedTypeName: org.springframework.batch.core.repository.dao.mongo.MongoSequenceIncrementer
+  # Move partition APIs
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.partition.support.Partitioner
+      newFullyQualifiedTypeName: org.springframework.batch.core.partition.Partitioner
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.partition.support.PartitionNameProvider
+      newFullyQualifiedTypeName: org.springframework.batch.core.partition.PartitionNameProvider
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.partition.support.PartitionStep
+      newFullyQualifiedTypeName: org.springframework.batch.core.partition.PartitionStep
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.partition.support.StepExecutionAggregator
+      newFullyQualifiedTypeName: org.springframework.batch.core.partition.StepExecutionAggregator
+  # Move listener classes
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.ChunkListener
+      newFullyQualifiedTypeName: org.springframework.batch.core.listener.ChunkListener
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.ItemProcessListener
+      newFullyQualifiedTypeName: org.springframework.batch.core.listener.ItemProcessListener
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.ItemReadListener
+      newFullyQualifiedTypeName: org.springframework.batch.core.listener.ItemReadListener
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.ItemWriteListener
+      newFullyQualifiedTypeName: org.springframework.batch.core.listener.ItemWriteListener
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.JobExecutionListener
+      newFullyQualifiedTypeName: org.springframework.batch.core.listener.JobExecutionListener
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.SkipListener
+      newFullyQualifiedTypeName: org.springframework.batch.core.listener.SkipListener
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.StepExecutionListener
+      newFullyQualifiedTypeName: org.springframework.batch.core.listener.StepExecutionListener
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.StepListener
+      newFullyQualifiedTypeName: org.springframework.batch.core.listener.StepListener
+  # Move job-related classes
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.Job
+      newFullyQualifiedTypeName: org.springframework.batch.core.job.Job
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.JobExecution
+      newFullyQualifiedTypeName: org.springframework.batch.core.job.JobExecution
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.JobExecutionException
+      newFullyQualifiedTypeName: org.springframework.batch.core.job.JobExecutionException
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.JobInstance
+      newFullyQualifiedTypeName: org.springframework.batch.core.job.JobInstance
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.JobInterruptedException
+      newFullyQualifiedTypeName: org.springframework.batch.core.job.JobInterruptedException
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.JobKeyGenerator
+      newFullyQualifiedTypeName: org.springframework.batch.core.job.JobKeyGenerator
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.DefaultJobKeyGenerator
+      newFullyQualifiedTypeName: org.springframework.batch.core.job.DefaultJobKeyGenerator
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.StartLimitExceededException
+      newFullyQualifiedTypeName: org.springframework.batch.core.job.StartLimitExceededException
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.UnexpectedJobExecutionException
+      newFullyQualifiedTypeName: org.springframework.batch.core.job.UnexpectedJobExecutionException
+  # Move job parameters classes
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.CompositeJobParametersValidator
+      newFullyQualifiedTypeName: org.springframework.batch.core.job.parameters.CompositeJobParametersValidator
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.DefaultJobParametersValidator
+      newFullyQualifiedTypeName: org.springframework.batch.core.job.parameters.DefaultJobParametersValidator
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.JobParameter
+      newFullyQualifiedTypeName: org.springframework.batch.core.job.parameters.JobParameter
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.JobParameters
+      newFullyQualifiedTypeName: org.springframework.batch.core.job.parameters.JobParameters
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.JobParametersBuilder
+      newFullyQualifiedTypeName: org.springframework.batch.core.job.parameters.JobParametersBuilder
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.JobParametersIncrementer
+      newFullyQualifiedTypeName: org.springframework.batch.core.job.parameters.JobParametersIncrementer
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.InvalidJobParametersException
+      newFullyQualifiedTypeName: org.springframework.batch.core.job.parameters.InvalidJobParametersException
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.JobParametersValidator
+      newFullyQualifiedTypeName: org.springframework.batch.core.job.parameters.JobParametersValidator
+  # Move step-related classes
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.Step
+      newFullyQualifiedTypeName: org.springframework.batch.core.step.Step
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.StepContribution
+      newFullyQualifiedTypeName: org.springframework.batch.core.step.StepContribution
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.StepExecution
+      newFullyQualifiedTypeName: org.springframework.batch.core.step.StepExecution
+  # Move parameter incrementers
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.launch.support.RunIdIncrementer
+      newFullyQualifiedTypeName: org.springframework.batch.core.job.parameters.RunIdIncrementer
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.core.launch.support.DataFieldMaxValueJobParametersIncrementer
+      newFullyQualifiedTypeName: org.springframework.batch.core.job.parameters.DataFieldMaxValueJobParametersIncrementer
+---
+# Migrate renamed APIs in Spring Batch 6.*
+# See: https://github.com/spring-projects/spring-batch/wiki/Spring-Batch-6.0-Migration-Guide#renamed-apis
+type: specs.openrewrite.org/v1beta/recipe
+name: org.apache.camel.upgrade.spring.SpringBatch6RenamedAPIs
+displayName: Migrate Spring Batch 6.* renamed APIs
+description: Migrates classes and methods that were renamed in Spring Batch 6.*.
+recipeList:
+  # Rename ChunkHandler to ChunkRequestHandler
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: org.springframework.batch.integration.chunk.ChunkHandler
+      newFullyQualifiedTypeName: org.springframework.batch.integration.chunk.ChunkRequestHandler
+  # Rename JobStep.setJobLauncher to setJobOperator
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: org.springframework.batch.core.step.job.JobStep setJobLauncher(org.springframework.batch.core.launch.JobLauncher)
+      newMethodName: setJobOperator
+  # Rename JobStepBuilder.launcher to operator
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: org.springframework.batch.core.step.builder.JobStepBuilder launcher(org.springframework.batch.core.launch.JobLauncher)
+      newMethodName: operator
+  # Rename SystemCommandTasklet.setJobExplorer to setJobRepository
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: org.springframework.batch.core.step.tasklet.SystemCommandTasklet setJobExplorer(org.springframework.batch.core.explore.JobExplorer)
+      newMethodName: setJobRepository
+---
+# Note: Removed APIs in Spring Batch 6.*
+# See: https://github.com/spring-projects/spring-batch/wiki/Spring-Batch-6.0-Migration-Guide#removed-apis
+# These APIs have been removed and require manual migration. Please refer to the migration guide for alternatives.

--- a/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/spring-boot-3-to-4.yaml
+++ b/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/spring-boot-3-to-4.yaml
@@ -21,6 +21,20 @@ name: org.apache.camel.upgrade.spring.UpgradeSpringBoot3To4
 displayName: Upgrade Spring Boot from 3.* to 4.*
 description: Upgrades Spring Boot dependencies from 3.* to 4.* based on https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-4.0-Migration-Guide
 recipeList:
+  # Update Java version to 17 (minimum for Spring Boot 4)
+  - org.apache.camel.upgrade.UpgradeToJava17
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: java.version
+      newValue: "17"
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: maven.compiler.source
+      newValue: "17"
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: maven.compiler.target
+      newValue: "17"
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: maven.compiler.release
+      newValue: "17"
   # Update Spring Boot version property
   - org.openrewrite.maven.ChangePropertyValue:
       key: spring-boot.version

--- a/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/spring-boot-3-to-4.yaml
+++ b/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/spring-boot-3-to-4.yaml
@@ -1,0 +1,46 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+# Upgrade Spring Boot from 3.* to 4.*
+type: specs.openrewrite.org/v1beta/recipe
+name: org.apache.camel.upgrade.spring.UpgradeSpringBoot3To4
+displayName: Upgrade Spring Boot from 3.* to 4.*
+description: Upgrades Spring Boot dependencies from 3.* to 4.* based on https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-4.0-Migration-Guide
+recipeList:
+  # Update Spring Boot version property
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: spring-boot.version
+      newValue: ${spring-boot-version}
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: spring-boot-version
+      newValue: ${spring-boot-version}
+  # Update parent POM version
+  - org.openrewrite.maven.ChangeParentPom:
+      oldGroupId: org.springframework.boot
+      oldArtifactId: spring-boot-starter-parent
+      newVersion: ${spring-boot-version}
+      allowVersionDowngrades: false
+  # Update Spring Boot dependencies
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: org.springframework.boot
+      artifactId: "*"
+      newVersion: ${spring-boot-version}
+  # Update Spring Boot Maven Plugin
+  - org.openrewrite.maven.UpgradePluginVersion:
+      groupId: org.springframework.boot
+      artifactId: spring-boot-maven-plugin
+      newVersion: ${spring-boot-version}

--- a/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/spring-framework-6-to-7.yaml
+++ b/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/spring-framework-6-to-7.yaml
@@ -1,0 +1,38 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+# Upgrade Spring Framework from 6.* to 7.*
+type: specs.openrewrite.org/v1beta/recipe
+name: org.apache.camel.upgrade.spring.UpgradeSpringFramework6To7
+displayName: Upgrade Spring Framework from 6.* to 7.*
+description: Upgrades Spring Framework dependencies from 6.* to 7.*.
+recipeList:
+  # Update Spring Framework version property
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: spring.version
+      newValue: ${springframework-version}
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: spring-framework.version
+      newValue: ${springframework-version}
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: springframework-version
+      newValue: ${springframework-version}
+  # Update Spring Framework dependencies
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: org.springframework
+      artifactId: "*"
+      newVersion: ${springframework-version}

--- a/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/spring-security-6-to-7.yaml
+++ b/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/spring-security-6-to-7.yaml
@@ -1,0 +1,35 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+# Upgrade Spring Security from 6.* to 7.*
+type: specs.openrewrite.org/v1beta/recipe
+name: org.apache.camel.upgrade.spring.UpgradeSpringSecurity6To7
+displayName: Upgrade Spring Security from 6.* to 7.*
+description: Upgrades Spring Security dependencies from 6.* to 7.*.
+recipeList:
+  # Update Spring Security version property
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: spring-security.version
+      newValue: ${spring-security-version}
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: spring-security-version
+      newValue: ${spring-security-version}
+  # Update Spring Security dependencies
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: org.springframework.security
+      artifactId: "*"
+      newVersion: ${spring-security-version}

--- a/camel-upgrade-recipes/pom.xml
+++ b/camel-upgrade-recipes/pom.xml
@@ -89,6 +89,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <version>${jspecify-version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.openrewrite</groupId>
             <artifactId>rewrite-test</artifactId>
             <scope>test</scope>

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel419/Pom419TestInfraRecipe.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel419/Pom419TestInfraRecipe.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.upgrade.camel419;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.xml.XPathMatcher;
+import org.openrewrite.xml.XmlVisitor;
+import org.openrewrite.xml.tree.Xml;
+
+import java.util.Optional;
+
+/**
+ * <p>
+ * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_test_infra">camel-test-infra</a>
+ * </p>
+ * Test infrastructure modules no longer produce separate test-JAR artifacts.
+ * Removes {@code <type>test-jar</type>} from camel-test-infra-* dependencies.
+ */
+public class Pom419TestInfraRecipe extends Recipe {
+
+    private static final XPathMatcher DEPENDENCY_MATCHER = new XPathMatcher("/project/dependencies/dependency");
+
+    @Override
+    public String getDisplayName() {
+        return "Remove test-jar type from camel-test-infra dependencies";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Removes <type>test-jar</type> from camel-test-infra-* dependencies as they no longer produce separate test-JAR artifacts.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new XmlVisitor<ExecutionContext>() {
+
+            @Override
+            public Xml visitTag(Xml.Tag tag, ExecutionContext ctx) {
+                Xml.Tag t = (Xml.Tag) super.visitTag(tag, ctx);
+
+                if (DEPENDENCY_MATCHER.matches(getCursor())) {
+                    // Check if this is a camel-test-infra-* dependency
+                    Optional<String> groupId = t.getChildValue("groupId");
+                    Optional<String> artifactId = t.getChildValue("artifactId");
+
+                    if (groupId.isPresent() && "org.apache.camel".equals(groupId.get()) &&
+                        artifactId.isPresent() && artifactId.get().startsWith("camel-test-infra-")) {
+
+                        // Check if it has <type>test-jar</type>
+                        Optional<Xml.Tag> typeTag = t.getChild("type");
+                        if (typeTag.isPresent() && "test-jar".equals(typeTag.get().getValue().orElse(""))) {
+                            // Remove the type tag
+                            t = t.withContent(
+                                t.getContent().stream()
+                                    .filter(content -> content != typeTag.get())
+                                    .toList()
+                            );
+                        }
+                    }
+                }
+
+                return t;
+            }
+        };
+    }
+}

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel419/Pom419TestInfraRecipe.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel419/Pom419TestInfraRecipe.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.upgrade.camel419;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.xml.XPathMatcher;
+import org.openrewrite.xml.XmlVisitor;
+import org.openrewrite.xml.tree.Xml;
+
+import java.util.Optional;
+
+/**
+ * <p>
+ * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_test_infra">camel-test-infra</a>
+ * </p>
+ * Test infrastructure modules no longer produce separate test-JAR artifacts.
+ * Removes {@code <type>test-jar</type>} from camel-test-infra-* dependencies.
+ */
+public class Pom419TestInfraRecipe extends Recipe {
+
+    private static final XPathMatcher DEPENDENCY_MATCHER = new XPathMatcher("/project/dependencies/dependency");
+
+    @Override
+    public String getDisplayName() {
+        return "Remove test-jar type from camel-test-infra dependencies";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Removes <type>test-jar</type> from camel-test-infra-* dependencies as they no longer produce separate test-JAR artifacts.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new XmlVisitor<ExecutionContext>() {
+
+            @Override
+            public Xml visitTag(Xml.Tag tag, ExecutionContext ctx) {
+                Xml.Tag t = (Xml.Tag) super.visitTag(tag, ctx);
+
+                if (DEPENDENCY_MATCHER.matches(getCursor())) {
+                    // Check if this is a camel-test-infra-* dependency
+                    Optional<String> groupId = t.getChildValue("groupId");
+                    Optional<String> artifactId = t.getChildValue("artifactId");
+
+                    if (groupId.isPresent() && "org.apache.camel".equals(groupId.get()) &&
+                        artifactId.isPresent() && artifactId.get().startsWith("camel-test-infra-")) {
+
+                        // Check if it has <type>test-jar</type>
+                        Optional<Xml.Tag> typeTag = t.getChild("type");
+                        if (typeTag.isPresent() && "test-jar".equals(typeTag.get().getValue().orElse(""))) {
+                            // Remove the type tag
+                            t = t.withContent(
+                                t.getContent().stream()
+                                    .filter(content -> !(content instanceof Xml.Tag &&
+                                                       "type".equals(((Xml.Tag) content).getName())))
+                                    .toList()
+                            );
+                        }
+                    }
+                }
+
+                return t;
+            }
+        };
+    }
+}

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel419/XmlDsl419SagaRecipe.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel419/XmlDsl419SagaRecipe.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.upgrade.camel419;
+
+import org.apache.camel.upgrade.AbstractCamelXmlVisitor;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.xml.XPathMatcher;
+import org.openrewrite.xml.tree.Xml;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * <p>
+ * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_saga_eip">Saga EIP</a>
+ * </p>
+ * Changed model for configuring completion and compensation URIs in XML DSL.
+ * Converts child elements to attributes.
+ */
+public class XmlDsl419SagaRecipe extends Recipe {
+
+    private static final XPathMatcher SAGA_MATCHER = new XPathMatcher("//saga");
+
+    @Override
+    public String getDisplayName() {
+        return "Camel XML DSL Saga EIP restructuring";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Apache Camel XML DSL migration from version 4.18 to 4.19. Converts saga compensation and completion child elements to attributes.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new AbstractCamelXmlVisitor() {
+
+            @Override
+            public Xml.Tag doVisitTag(final Xml.Tag tag, final ExecutionContext ctx) {
+                Xml.Tag t = super.doVisitTag(tag, ctx);
+
+                if (SAGA_MATCHER.matches(getCursor())) {
+                    List<Xml.Tag> children = new ArrayList<>(t.getChildren());
+                    List<Xml.Attribute> attributes = new ArrayList<>(t.getAttributes());
+                    boolean modified = false;
+
+                    modified |= convertChildElementToAttribute(children, attributes, "compensation");
+                    modified |= convertChildElementToAttribute(children, attributes, "completion");
+
+                    if (modified) {
+                        t = t.withContent(children);
+                        t = t.withAttributes(attributes);
+                    }
+                }
+
+                return t;
+            }
+
+            private boolean convertChildElementToAttribute(List<Xml.Tag> children, List<Xml.Attribute> attributes, String elementName) {
+                Optional<Xml.Tag> childTag = children.stream()
+                        .filter(child -> elementName.equals(child.getName()))
+                        .findFirst();
+
+                if (childTag.isPresent()) {
+                    Xml.Tag tag = childTag.get();
+                    String uri = null;
+
+                    // First, try to get the uri from the 'uri' attribute
+                    Optional<Xml.Attribute> uriAttr = tag.getAttributes().stream()
+                            .filter(attr -> "uri".equals(attr.getKeyAsString()))
+                            .findFirst();
+
+                    if (uriAttr.isPresent()) {
+                        uri = uriAttr.get().getValueAsString();
+                    } else if (tag.getValue().isPresent()) {
+                        // Fallback to text content if no uri attribute
+                        uri = tag.getValue().get().trim();
+                    }
+
+                    if (uri != null && !uri.isEmpty()) {
+                        children.removeIf(child -> elementName.equals(child.getName()));
+
+                        if (attributes.stream().noneMatch(a -> elementName.equals(a.getKeyAsString()))) {
+                            attributes.add(new Xml.Attribute(
+                                    org.openrewrite.Tree.randomId(),
+                                    " ",
+                                    org.openrewrite.marker.Markers.EMPTY,
+                                    new Xml.Ident(org.openrewrite.Tree.randomId(), "", org.openrewrite.marker.Markers.EMPTY, elementName),
+                                    "",
+                                    new Xml.Attribute.Value(
+                                            org.openrewrite.Tree.randomId(),
+                                            "",
+                                            org.openrewrite.marker.Markers.EMPTY,
+                                            Xml.Attribute.Value.Quote.Double,
+                                            uri
+                                    )
+                            ));
+                        }
+                        return true;
+                    }
+                }
+                return false;
+            }
+        };
+    }
+}

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel419/XmlDsl419SagaRecipe.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel419/XmlDsl419SagaRecipe.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.upgrade.camel419;
+
+import org.apache.camel.upgrade.AbstractCamelXmlVisitor;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.xml.XPathMatcher;
+import org.openrewrite.xml.tree.Xml;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * <p>
+ * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_saga_eip">Saga EIP</a>
+ * </p>
+ * Changed model for configuring completion and compensation URIs in XML DSL.
+ * Converts child elements to attributes.
+ */
+public class XmlDsl419SagaRecipe extends Recipe {
+
+    private static final XPathMatcher SAGA_MATCHER = new XPathMatcher("//saga");
+
+    @Override
+    public String getDisplayName() {
+        return "Camel XML DSL Saga EIP restructuring";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Apache Camel XML DSL migration from version 4.18 to 4.19. Converts saga compensation and completion child elements to attributes.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new AbstractCamelXmlVisitor() {
+
+            @Override
+            public Xml.Tag doVisitTag(final Xml.Tag tag, final ExecutionContext ctx) {
+                Xml.Tag t = super.doVisitTag(tag, ctx);
+
+                if (SAGA_MATCHER.matches(getCursor())) {
+                    List<Xml.Tag> children = new ArrayList<>(t.getChildren());
+                    List<Xml.Attribute> attributes = new ArrayList<>(t.getAttributes());
+                    boolean modified = false;
+
+                    modified |= convertChildElementToAttribute(children, attributes, "compensation");
+                    modified |= convertChildElementToAttribute(children, attributes, "completion");
+
+                    if (modified) {
+                        t = t.withContent(children);
+                        t = t.withAttributes(attributes);
+                    }
+                }
+
+                return t;
+            }
+
+            private boolean convertChildElementToAttribute(List<Xml.Tag> children, List<Xml.Attribute> attributes, String elementName) {
+                Optional<Xml.Tag> childTag = children.stream()
+                        .filter(child -> elementName.equals(child.getName()))
+                        .findFirst();
+
+                if (childTag.isPresent() && childTag.get().getValue().isPresent()) {
+                    String uri = childTag.get().getValue().get().trim();
+                    children.removeIf(child -> elementName.equals(child.getName()));
+
+                    if (attributes.stream().noneMatch(a -> elementName.equals(a.getKeyAsString()))) {
+                        attributes.add(new Xml.Attribute(
+                                org.openrewrite.Tree.randomId(),
+                                " ",
+                                org.openrewrite.marker.Markers.EMPTY,
+                                new Xml.Ident(org.openrewrite.Tree.randomId(), "", org.openrewrite.marker.Markers.EMPTY, elementName),
+                                "",
+                                new Xml.Attribute.Value(
+                                        org.openrewrite.Tree.randomId(),
+                                        "",
+                                        org.openrewrite.marker.Markers.EMPTY,
+                                        Xml.Attribute.Value.Quote.Double,
+                                        uri
+                                )
+                        ));
+                    }
+                    return true;
+                }
+                return false;
+            }
+        };
+    }
+}

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel419/XmlDsl419WireTapRecipe.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel419/XmlDsl419WireTapRecipe.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.upgrade.camel419;
+
+import org.apache.camel.upgrade.AbstractCamelXmlVisitor;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.xml.XPathMatcher;
+import org.openrewrite.xml.tree.Xml;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * <p>
+ * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_wiretap_eip">WireTap EIP</a>
+ * </p>
+ * The WireTap EIP pattern option has been removed.
+ */
+public class XmlDsl419WireTapRecipe extends Recipe {
+
+    private static final XPathMatcher WIRETAP_MATCHER = new XPathMatcher("//wireTap");
+
+    @Override
+    public String getDisplayName() {
+        return "Camel XML DSL WireTap pattern removal";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Apache Camel XML DSL migration from version 4.18 to 4.19. Removes the unused pattern attribute from wireTap elements.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new AbstractCamelXmlVisitor() {
+
+            @Override
+            public Xml.Tag doVisitTag(final Xml.Tag tag, final ExecutionContext ctx) {
+                Xml.Tag t = super.doVisitTag(tag, ctx);
+
+                if (WIRETAP_MATCHER.matches(getCursor())) {
+                    List<Xml.Attribute> attributes = new ArrayList<>(t.getAttributes());
+                    boolean removed = attributes.removeIf(a -> "pattern".equals(a.getKeyAsString()));
+
+                    if (removed) {
+                        t = t.withAttributes(attributes);
+                    }
+                }
+
+                return t;
+            }
+        };
+    }
+}

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel419/YamlDsl419RoutePolicyRecipe.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel419/YamlDsl419RoutePolicyRecipe.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.upgrade.camel419;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.apache.camel.upgrade.AbstractCamelYamlVisitor;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.yaml.JsonPathMatcher;
+import org.openrewrite.yaml.tree.Yaml;
+
+/**
+ * <p>
+ * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_yaml_io_camel_xml_io">YAML DSL</a>
+ * </p>
+ * In the YAML DSL we have renamed routePolicy to routePolicyRef.
+ */
+@EqualsAndHashCode(callSuper = false)
+@Value
+public class YamlDsl419RoutePolicyRecipe extends Recipe {
+
+    private static final JsonPathMatcher ROUTE_POLICY_MATCHER = new JsonPathMatcher("$..route.routePolicy");
+
+    @Override
+    public String getDisplayName() {
+        return "Camel YAML DSL routePolicy renaming";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Apache Camel YAML DSL migration from version 4.18 to 4.19. Renames routePolicy to routePolicyRef.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+
+        return new AbstractCamelYamlVisitor() {
+
+            @Override
+            protected void clearLocalCache() {
+                //nothing to do
+            }
+
+            @Override
+            public Yaml.Mapping.Entry doVisitMappingEntry(Yaml.Mapping.Entry entry, ExecutionContext ctx) {
+                Yaml.Mapping.Entry e = super.doVisitMappingEntry(entry, ctx);
+
+                // Check if this is routePolicy within a route definition
+                if (ROUTE_POLICY_MATCHER.matches(getCursor()) &&
+                    entry.getKey() instanceof Yaml.Scalar &&
+                    "routePolicy".equals((entry.getKey()).getValue())) {
+
+                    // Rename to routePolicyRef
+                    e = entry.withKey(((Yaml.Scalar) entry.getKey()).withValue("routePolicyRef"));
+                }
+
+                return e;
+            }
+        };
+    }
+}

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel419/YamlDsl419RoutePolicyRecipe.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel419/YamlDsl419RoutePolicyRecipe.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.upgrade.camel419;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.apache.camel.upgrade.AbstractCamelYamlVisitor;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.yaml.tree.Yaml;
+
+/**
+ * <p>
+ * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_yaml_dsl">YAML DSL</a>
+ * </p>
+ * In the YAML DSL we have renamed routePolicy to routePolicyRef.
+ */
+@EqualsAndHashCode(callSuper = false)
+@Value
+public class YamlDsl419RoutePolicyRecipe extends Recipe {
+
+    @Override
+    public String getDisplayName() {
+        return "Camel YAML DSL routePolicy renaming";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Apache Camel YAML DSL migration from version 4.18 to 4.19. Renames routePolicy to routePolicyRef.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+
+        return new AbstractCamelYamlVisitor() {
+
+            @Override
+            protected void clearLocalCache() {
+                //nothing to do
+            }
+
+            @Override
+            public Yaml.Mapping.Entry doVisitMappingEntry(Yaml.Mapping.Entry entry, ExecutionContext ctx) {
+                Yaml.Mapping.Entry e = super.doVisitMappingEntry(entry, ctx);
+
+                // Check if we're inside a route mapping and this entry has key "routePolicy"
+                if (entry.getKey() instanceof Yaml.Scalar &&
+                    "routePolicy".equals(((Yaml.Scalar) entry.getKey()).getValue())) {
+
+                    // Rename to routePolicyRef
+                    e = entry.withKey(((Yaml.Scalar) entry.getKey()).withValue("routePolicyRef"));
+                }
+
+                return e;
+            }
+        };
+    }
+}

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel419/YamlDsl419SagaRecipe.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel419/YamlDsl419SagaRecipe.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.upgrade.camel419;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.apache.camel.upgrade.AbstractCamelYamlVisitor;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.yaml.JsonPathMatcher;
+import org.openrewrite.yaml.tree.Yaml;
+
+/**
+ * <p>
+ * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_saga_eip">Saga EIP</a>
+ * </p>
+ * Changed model for configuring completion and compensation URIs in YAML DSL.
+ * Flattens nested uri fields to direct attribute values.
+ */
+@EqualsAndHashCode(callSuper = false)
+@Value
+public class YamlDsl419SagaRecipe extends Recipe {
+
+    private static final JsonPathMatcher COMPENSATION_MATCHER = new JsonPathMatcher("$..saga.compensation");
+    private static final JsonPathMatcher COMPLETION_MATCHER = new JsonPathMatcher("$..saga.completion");
+
+    @Override
+    public String getDisplayName() {
+        return "Camel YAML DSL Saga EIP restructuring";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Apache Camel YAML DSL migration from version 4.18 to 4.19. Flattens saga compensation and completion nested uri to direct values.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+
+        return new AbstractCamelYamlVisitor() {
+
+            @Override
+            protected void clearLocalCache() {
+                //nothing to do
+            }
+
+            @Override
+            public Yaml.Mapping.Entry doVisitMappingEntry(Yaml.Mapping.Entry entry, ExecutionContext ctx) {
+                Yaml.Mapping.Entry e = super.doVisitMappingEntry(entry, ctx);
+
+                // Check if this is compensation or completion with nested uri
+                if ((COMPENSATION_MATCHER.matches(getCursor()) || COMPLETION_MATCHER.matches(getCursor())) &&
+                    entry.getValue() instanceof Yaml.Mapping) {
+
+                    Yaml.Mapping nestedMapping = (Yaml.Mapping) entry.getValue();
+                    // Look for uri field in nested mapping
+                    for (Yaml.Mapping.Entry nestedEntry : nestedMapping.getEntries()) {
+                        if (nestedEntry.getKey() instanceof Yaml.Scalar &&
+                            "uri".equals(((Yaml.Scalar) nestedEntry.getKey()).getValue()) &&
+                            nestedEntry.getValue() instanceof Yaml.Scalar) {
+
+                            // Replace the nested mapping with just the uri scalar value
+                            return entry.withValue(nestedEntry.getValue());
+                        }
+                    }
+                }
+
+                return e;
+            }
+        };
+    }
+}

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel419/YamlDsl419WireTapRecipe.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel419/YamlDsl419WireTapRecipe.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.upgrade.camel419;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+import org.apache.camel.upgrade.AbstractCamelYamlVisitor;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.yaml.JsonPathMatcher;
+import org.openrewrite.yaml.tree.Yaml;
+
+/**
+ * <p>
+ * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_wiretap_eip">WireTap EIP</a>
+ * </p>
+ * The WireTap EIP pattern option has been removed.
+ */
+@EqualsAndHashCode(callSuper = false)
+@Value
+public class YamlDsl419WireTapRecipe extends Recipe {
+
+    private static final JsonPathMatcher WIRETAP_PATTERN_MATCHER = new JsonPathMatcher("$..wireTap.pattern");
+
+    @Override
+    public String getDisplayName() {
+        return "Camel YAML DSL WireTap pattern removal";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Apache Camel YAML DSL migration from version 4.18 to 4.19. Removes the unused pattern attribute from wireTap elements.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+
+        return new AbstractCamelYamlVisitor() {
+
+            @Override
+            protected void clearLocalCache() {
+                //nothing to do
+            }
+
+            @Override
+            public Yaml.Mapping.Entry doVisitMappingEntry(Yaml.Mapping.Entry entry, ExecutionContext ctx) {
+                Yaml.Mapping.Entry e = super.doVisitMappingEntry(entry, ctx);
+
+                // Remove pattern entry from wireTap
+                if (WIRETAP_PATTERN_MATCHER.matches(getCursor())) {
+                    return null;
+                }
+
+                return e;
+            }
+        };
+    }
+}

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel47/Java47Recipes.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel47/Java47Recipes.java
@@ -18,7 +18,6 @@ package org.apache.camel.upgrade.camel47;
 
 import lombok.EqualsAndHashCode;
 import lombok.RequiredArgsConstructor;
-import org.antlr.v4.runtime.misc.Triple;
 import org.apache.camel.upgrade.AbstractCamelJavaVisitor;
 import org.apache.camel.upgrade.RecipesUtil;
 import org.openrewrite.ExecutionContext;
@@ -39,10 +38,24 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class Java47Recipes extends Recipe {
 
+    /**
+     * Simple triple class to hold three related values
+     */
+    private static class Triple {
+        final String a;
+        final String b;
+        final String c;
+
+        Triple(String a, String b, String c) {
+            this.a = a;
+            this.b = b;
+            this.c = c;
+        }
+    }
 
     private static final String MATCHER_GET_HEADER = "org.apache.camel.Message getHeader(java.lang.String, java.lang.Class)";
     private static final String MATCHER_GET_IN = "org.apache.camel.Exchange getIn()";
-    private static final List<Triple<String, String, String>> HEADERS_MAP = Arrays.asList(
+    private static final List<Triple> HEADERS_MAP = Arrays.asList(
             new Triple("org.apache.camel.Message getHeader(java.lang.String, java.lang.Class)", "Exchange.HTTP_SERVLET_REQUEST", "#{any(org.apache.camel.Exchange)}.getMessage(HttpMessage.class).getRequest()"),
             new Triple("org.apache.camel.Message getHeader(java.lang.String, java.lang.Class)", "Exchange.HTTP_SERVLET_RESPONSE", "#{any(org.apache.camel.Exchange)}.getMessage(HttpMessage.class).getResponse()"));
 

--- a/camel-upgrade-recipes/src/main/resources/META-INF/rewrite/4.19.yaml
+++ b/camel-upgrade-recipes/src/main/resources/META-INF/rewrite/4.19.yaml
@@ -28,7 +28,36 @@ name: org.apache.camel.upgrade.camel419.CamelMigrationRecipe
 displayName: Migrates `camel 4.18` application to `camel 4.19`
 description: Migrates `camel 4.18` application to `camel 4.19`.
 recipeList:
+  - org.apache.camel.upgrade.camel419.removedComponents
   - org.apache.camel.upgrade.camel419.migrateGroovyXml
+  - org.apache.camel.upgrade.camel419.XmlDsl419SagaRecipe
+  - org.apache.camel.upgrade.camel419.YamlDsl419SagaRecipe
+  - org.apache.camel.upgrade.camel419.Pom419TestInfraRecipe
+  - org.apache.camel.upgrade.camel419.YamlDsl419RoutePolicyRecipe
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.apache.camel.upgrade.camel419.removedComponents
+displayName: The camel-test module has been removed from camel-bom
+description: The camel-test module has been removed from camel-bom.
+recipeList:
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: org.apache.camel
+      artifactId: camel-test
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: org.apache.camel
+      artifactId: camel-cloud
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: org.apache.camel
+      artifactId: camel-service
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: org.apache.camel
+      artifactId: camel-nitrite
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: org.apache.camel
+      artifactId: camel-torchserve
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: org.apache.camel
+      artifactId: camel-test-infra-torchserve
 ---
 # https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_groovy_xml
 # Migrate camel-groovy-xml to camel-groovy

--- a/camel-upgrade-recipes/src/main/resources/META-INF/rewrite/4.19.yaml
+++ b/camel-upgrade-recipes/src/main/resources/META-INF/rewrite/4.19.yaml
@@ -1,0 +1,44 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#####
+# Rules coming from https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html
+#####
+
+#####
+# Update the Camel project from 4.18 to 4.19
+#####
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.apache.camel.upgrade.camel419.CamelMigrationRecipe
+displayName: Migrates `camel 4.18` application to `camel 4.19`
+description: Migrates `camel 4.18` application to `camel 4.19`.
+recipeList:
+  - org.apache.camel.upgrade.camel419.migrateGroovyXml
+---
+# https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_groovy_xml
+# Migrate camel-groovy-xml to camel-groovy
+type: specs.openrewrite.org/v1beta/recipe
+name: org.apache.camel.upgrade.camel419.migrateGroovyXml
+displayName: Migrate camel-groovy-xml to camel-groovy
+description: camel-groovy-xml has been removed and moved into camel-groovy. Changes the dependency from camel-groovy-xml to camel-groovy.
+recipeList:
+  - org.openrewrite.maven.ChangeDependencyGroupIdAndArtifactId:
+      oldGroupId: org.apache.camel
+      oldArtifactId: camel-groovy-xml
+      newGroupId: org.apache.camel
+      newArtifactId: camel-groovy

--- a/camel-upgrade-recipes/src/main/resources/META-INF/rewrite/4.19.yaml
+++ b/camel-upgrade-recipes/src/main/resources/META-INF/rewrite/4.19.yaml
@@ -29,6 +29,12 @@ displayName: Migrates `camel 4.18` application to `camel 4.19`
 description: Migrates `camel 4.18` application to `camel 4.19`.
 recipeList:
   - org.apache.camel.upgrade.camel419.migrateGroovyXml
+  - org.apache.camel.upgrade.camel419.Pom419TestInfraRecipe
+  - org.apache.camel.upgrade.camel419.XmlDsl419WireTapRecipe
+  - org.apache.camel.upgrade.camel419.YamlDsl419WireTapRecipe
+  - org.apache.camel.upgrade.camel419.XmlDsl419SagaRecipe
+  - org.apache.camel.upgrade.camel419.YamlDsl419SagaRecipe
+  - org.apache.camel.upgrade.camel419.YamlDsl419RoutePolicyRecipe
 ---
 # https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_groovy_xml
 # Migrate camel-groovy-xml to camel-groovy

--- a/camel-upgrade-recipes/src/main/resources/META-INF/rewrite/latest.yaml
+++ b/camel-upgrade-recipes/src/main/resources/META-INF/rewrite/latest.yaml
@@ -20,6 +20,7 @@ name: org.apache.camel.upgrade.CamelMigrationRecipe
 displayName: Migrate to @camel-latest-version@
 description: Migrates Apache Camel application to @camel-latest-version@.
 recipeList:
+  - org.apache.camel.upgrade.camel419.CamelMigrationRecipe
   - org.apache.camel.upgrade.camel418.CamelMigrationRecipe
   - org.apache.camel.upgrade.camel417.CamelMigrationRecipe
   - org.apache.camel.upgrade.camel416.CamelMigrationRecipe
@@ -50,3 +51,6 @@ recipeList:
       groupId: 'org.apache.camel'
       artifactId: '*'
       newVersion: @camel-latest-version@
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: camel.version
+      newValue: @camel-latest-version@

--- a/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelTestUtil.java
+++ b/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelTestUtil.java
@@ -54,7 +54,8 @@ public class CamelTestUtil {
         v4_15(4, 15, 0),
         v4_16(4, 16, 0),
         v4_17(4, 17, 0),
-        v4_18(4, 18, 0);
+        v4_18(4, 18, 0),
+        v4_19(4, 19, 0);
 
         private int major;
         private int minor;

--- a/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelUpdate415Test.java
+++ b/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelUpdate415Test.java
@@ -300,7 +300,7 @@ public class CamelUpdate415Test implements RewriteTest {
 
                         new JaxbDataFormat().setNamespacePrefixRef("777");
 
-                        SoapDataFormat soap = new SoapDataFormat();;
+                        SoapDataFormat soap = new SoapDataFormat();
 
                         soap.setNamespacePrefixRef("888");
                         soap.setElementNameStrategyRef("999");
@@ -339,7 +339,7 @@ public class CamelUpdate415Test implements RewriteTest {
                         
                         new JaxbDataFormat().setNamespacePrefix("777");
                         
-                        SoapDataFormat soap = new SoapDataFormat();;
+                        SoapDataFormat soap = new SoapDataFormat();
                       
                         soap.setNamespacePrefix("888");
                         soap.setElementNameStrategy("999");

--- a/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelUpdate419Test.java
+++ b/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelUpdate419Test.java
@@ -16,14 +16,15 @@
  */
 package org.apache.camel.upgrade;
 
+import org.apache.camel.upgrade.camel419.*;
 import org.junit.jupiter.api.Test;
-import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.test.TypeValidation;
 
 import static org.openrewrite.maven.Assertions.pomXml;
-import static org.openrewrite.properties.Assertions.properties;
+import static org.openrewrite.xml.Assertions.xml;
+import static org.openrewrite.yaml.Assertions.yaml;
 
 //class has to stay public, because test is extended in project quarkus-updates
 public class CamelUpdate419Test implements RewriteTest {
@@ -35,5 +36,321 @@ public class CamelUpdate419Test implements RewriteTest {
                         "camel-core-model", "camel-api"))
                 .typeValidationOptions(TypeValidation.none());
     }
+
+    /**
+     * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_18.html#_camel_bom">camel-bom</a>
+     */
+    @Test
+    void camelBom() {
+        //language=xml
+        rewriteRun(pomXml(
+                """
+                  <project>
+                     <modelVersion>4.0.0</modelVersion>
+      
+                     <artifactId>test</artifactId>
+                     <groupId>org.apache.camel.test</groupId>
+                     <version>1.0.0</version>
+      
+                     <properties>
+                         <camel.version>3.21.0</camel.version>
+                     </properties>
+      
+                     <dependencies>
+                         <dependency>
+                             <groupId>org.apache.camel</groupId>
+                             <artifactId>camel-api</artifactId>
+                             <version>${camel.version}</version>
+                         </dependency>
+                         <dependency>
+                             <groupId>org.apache.camel</groupId>
+                             <artifactId>camel-test</artifactId>
+                             <version>${camel.version}</version>
+                         </dependency>
+                      </dependencies>
+      
+                  </project>
+                  """,
+                """
+                  <project>
+                     <modelVersion>4.0.0</modelVersion>
+      
+                     <artifactId>test</artifactId>
+                     <groupId>org.apache.camel.test</groupId>
+                     <version>1.0.0</version>
+      
+                     <properties>
+                         <camel.version>3.21.0</camel.version>
+                     </properties>
+      
+                     <dependencies>
+                         <dependency>
+                             <groupId>org.apache.camel</groupId>
+                             <artifactId>camel-api</artifactId>
+                             <version>${camel.version}</version>
+                         </dependency>
+                      </dependencies>
+      
+                  </project>
+                  """));
+    }
+
+    /**
+     * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_saga_eip">Saga EIP</a>
+     */
+    @Test
+    void sagaEipXml() {
+        //language=xml
+        rewriteRun(xml(
+          """
+            <route>
+                <from uri="direct:start"/>
+                <saga sagaService="mySagaService">
+                    <compensation uri="mock:compensation"/>
+                    <completion uri="mock:completion"/>
+                    <option key="myOptionKey">
+                        <constant>myOptionValue</constant>
+                    </option>
+                    <option key="myOptionKey2">
+                        <constant>myOptionValue2</constant>
+                    </option>
+                </saga>
+                <choice>
+                    <when>
+                        <simple>${body} == 'fail'</simple>
+                        <throwException exceptionType="java.lang.RuntimeException" message="fail"/>
+                    </when>
+                </choice>
+                <to uri="mock:end"/>
+            </route>
+            """,
+          """
+            <route>
+                <from uri="direct:start"/>
+                <saga sagaService="mySagaService" compensation="mock:compensation" completion="mock:completion">
+                    <option key="myOptionKey">
+                        <constant>myOptionValue</constant>
+                    </option>
+                    <option key="myOptionKey2">
+                        <constant>myOptionValue2</constant>
+                    </option>
+                </saga>
+                <choice>
+                    <when>
+                        <simple>${body} == 'fail'</simple>
+                        <throwException exceptionType="java.lang.RuntimeException" message="fail"/>
+                    </when>
+                </choice>
+                <to uri="mock:end"/>
+            </route>
+            """));
+    }
+
+    /**
+     * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_saga_eip">Saga EIP</a>
+     */
+    @Test
+    void sagaEipYaml() {
+        //language=yaml
+        rewriteRun(yaml(
+          """
+            - route:
+                from:
+                  uri: direct:start
+                steps:
+                  - saga:
+                      compensation:
+                        uri: direct:compensate
+                      completion:
+                        uri: direct:complete
+                      steps:
+                        - to:
+                            uri: direct:action
+            """,
+          """
+            - route:
+                from:
+                  uri: direct:start
+                steps:
+                  - saga:
+                      compensation: direct:compensate
+                      completion: direct:complete
+                      steps:
+                        - to:
+                            uri: direct:action
+            """));
+    }
+
+
+    /**
+     * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_test_infra">camel-test-infra</a>
+     */
+    @Test
+    void testInfraTestJarRemoval() {
+        //language=xml
+        rewriteRun(spec -> spec.recipe(new Pom419TestInfraRecipe()),
+                pomXml(
+                        """
+                          <project>
+                              <groupId>com.example</groupId>
+                              <artifactId>test-project</artifactId>
+                              <version>1.0</version>
+                              <dependencies>
+                                  <dependency>
+                                      <groupId>org.apache.camel</groupId>
+                                      <artifactId>camel-test-infra-kafka</artifactId>
+                                      <version>4.18.0</version>
+                                      <type>test-jar</type>
+                                      <scope>test</scope>
+                                  </dependency>
+                                  <dependency>
+                                      <groupId>org.apache.camel</groupId>
+                                      <artifactId>camel-test-infra-common</artifactId>
+                                      <version>4.18.0</version>
+                                      <type>test-jar</type>
+                                      <scope>test</scope>
+                                  </dependency>
+                                  <dependency>
+                                      <groupId>org.apache.camel</groupId>
+                                      <artifactId>camel-core</artifactId>
+                                      <version>4.18.0</version>
+                                  </dependency>
+                              </dependencies>
+                          </project>
+                          """,
+                        """
+                          <project>
+                              <groupId>com.example</groupId>
+                              <artifactId>test-project</artifactId>
+                              <version>1.0</version>
+                              <dependencies>
+                                  <dependency>
+                                      <groupId>org.apache.camel</groupId>
+                                      <artifactId>camel-test-infra-kafka</artifactId>
+                                      <version>4.18.0</version>
+                                      <scope>test</scope>
+                                  </dependency>
+                                  <dependency>
+                                      <groupId>org.apache.camel</groupId>
+                                      <artifactId>camel-test-infra-common</artifactId>
+                                      <version>4.18.0</version>
+                                      <scope>test</scope>
+                                  </dependency>
+                                  <dependency>
+                                      <groupId>org.apache.camel</groupId>
+                                      <artifactId>camel-core</artifactId>
+                                      <version>4.18.0</version>
+                                  </dependency>
+                              </dependencies>
+                          </project>
+                          """));
+    }
+
+    /**
+     * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_yaml_io_camel_xml_io">YAML DSL</a>
+     */
+    @Test
+    void yamlDslRoutePolicyRename() {
+        //language=yaml
+        rewriteRun(yaml(
+          """
+            - route:
+                id: myRoute
+                routePolicy: myPolicy
+                from:
+                  uri: direct:start
+                steps:
+                  - to:
+                      uri: mock:result
+            """,
+          """
+            - route:
+                id: myRoute
+                routePolicyRef: myPolicy
+                from:
+                  uri: direct:start
+                steps:
+                  - to:
+                      uri: mock:result
+            """));
+    }
+    /**
+     * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_18.html#_camel_bom">camel-bom</a>
+     */
+    @Test
+    void removedComponents() {
+        //language=xml
+        rewriteRun(pomXml(
+                """
+                  <project>
+                     <modelVersion>4.0.0</modelVersion>
+      
+                     <artifactId>test</artifactId>
+                     <groupId>org.apache.camel.test</groupId>
+                     <version>1.0.0</version>
+      
+                     <properties>
+                         <camel.version>4.18.0</camel.version>
+                     </properties>
+      
+                     <dependencies>
+                         <dependency>
+                             <groupId>org.apache.camel</groupId>
+                             <artifactId>camel-api</artifactId>
+                             <version>${camel.version}</version>
+                         </dependency>
+                         <dependency>
+                             <groupId>org.apache.camel</groupId>
+                             <artifactId>camel-cloud</artifactId>
+                             <version>${camel.version}</version>
+                         </dependency>
+                         <dependency>
+                             <groupId>org.apache.camel</groupId>
+                             <artifactId>camel-service</artifactId>
+                             <version>${camel.version}</version>
+                         </dependency>
+                         <dependency>
+                             <groupId>org.apache.camel</groupId>
+                             <artifactId>camel-nitrite</artifactId>
+                             <version>${camel.version}</version>
+                         </dependency>
+                         <dependency>
+                             <groupId>org.apache.camel</groupId>
+                             <artifactId>camel-torchserve</artifactId>
+                             <version>${camel.version}</version>
+                         </dependency>
+                         <dependency>
+                             <groupId>org.apache.camel</groupId>
+                             <artifactId>camel-test-infra-torchserve</artifactId>
+                             <version>${camel.version}</version>
+                         </dependency>
+                      </dependencies>
+      
+                  </project>
+                  """,
+                """
+                  <project>
+                     <modelVersion>4.0.0</modelVersion>
+      
+                     <artifactId>test</artifactId>
+                     <groupId>org.apache.camel.test</groupId>
+                     <version>1.0.0</version>
+      
+                     <properties>
+                         <camel.version>4.18.0</camel.version>
+                     </properties>
+      
+                     <dependencies>
+                         <dependency>
+                             <groupId>org.apache.camel</groupId>
+                             <artifactId>camel-api</artifactId>
+                             <version>${camel.version}</version>
+                         </dependency>
+                      </dependencies>
+      
+                  </project>
+                  """));
+    }
+
 
 }

--- a/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelUpdate419Test.java
+++ b/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelUpdate419Test.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.upgrade;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
+
+import static org.openrewrite.maven.Assertions.pomXml;
+import static org.openrewrite.properties.Assertions.properties;
+
+//class has to stay public, because test is extended in project quarkus-updates
+public class CamelUpdate419Test implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipeFromResources("org.apache.camel.upgrade.camel419.CamelMigrationRecipe")
+                .parser(CamelTestUtil.parserFromClasspath(CamelTestUtil.CamelVersion.v4_18,
+                        "camel-core-model", "camel-api"))
+                .typeValidationOptions(TypeValidation.none());
+    }
+
+}

--- a/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelUpdate419Test.java
+++ b/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelUpdate419Test.java
@@ -16,14 +16,17 @@
  */
 package org.apache.camel.upgrade;
 
+import org.apache.camel.upgrade.camel419.*;
 import org.junit.jupiter.api.Test;
 import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.test.TypeValidation;
 
+import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.maven.Assertions.pomXml;
-import static org.openrewrite.properties.Assertions.properties;
+import static org.openrewrite.xml.Assertions.xml;
+import static org.openrewrite.yaml.Assertions.yaml;
 
 //class has to stay public, because test is extended in project quarkus-updates
 public class CamelUpdate419Test implements RewriteTest {
@@ -34,6 +37,227 @@ public class CamelUpdate419Test implements RewriteTest {
                 .parser(CamelTestUtil.parserFromClasspath(CamelTestUtil.CamelVersion.v4_18,
                         "camel-core-model", "camel-api"))
                 .typeValidationOptions(TypeValidation.none());
+    }
+
+    /**
+     * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_wiretap_eip">WireTap EIP</a>
+     */
+    @DocumentExample
+    @Test
+    void wireTapPatternXml() {
+        //language=xml
+        rewriteRun(xml(
+          """
+            <camelContext id="camel" xmlns="http://camel.apache.org/schema/spring">
+                <route>
+                    <from uri="direct:start"/>
+                    <wireTap uri="direct:tap" pattern="InOnly">
+                        <body><constant>tapped</constant></body>
+                    </wireTap>
+                    <to uri="mock:result"/>
+                </route>
+            </camelContext>
+            """,
+          """
+            <camelContext id="camel" xmlns="http://camel.apache.org/schema/spring">
+                <route>
+                    <from uri="direct:start"/>
+                    <wireTap uri="direct:tap">
+                        <body><constant>tapped</constant></body>
+                    </wireTap>
+                    <to uri="mock:result"/>
+                </route>
+            </camelContext>
+            """));
+    }
+
+    /**
+     * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_wiretap_eip">WireTap EIP</a>
+     */
+    @Test
+    void wireTapPatternYaml() {
+        //language=yaml
+        rewriteRun(yaml(
+          """
+            - route:
+                from:
+                  uri: direct:start
+                steps:
+                  - wireTap:
+                      uri: direct:tap
+                      pattern: InOnly
+                  - to:
+                      uri: mock:result
+            """,
+          """
+            - route:
+                from:
+                  uri: direct:start
+                steps:
+                  - wireTap:
+                      uri: direct:tap
+                  - to:
+                      uri: mock:result
+            """));
+    }
+
+    /**
+     * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_saga_eip">Saga EIP</a>
+     */
+    @Test
+    void sagaEipXml() {
+        //language=xml
+        rewriteRun(xml(
+          """
+            <camelContext id="camel" xmlns="http://camel.apache.org/schema/spring">
+                <route>
+                    <from uri="direct:start"/>
+                    <saga>
+                        <compensation>direct:compensate</compensation>
+                        <completion>direct:complete</completion>
+                        <to uri="direct:action"/>
+                    </saga>
+                </route>
+            </camelContext>
+            """,
+          """
+            <camelContext id="camel" xmlns="http://camel.apache.org/schema/spring">
+                <route>
+                    <from uri="direct:start"/>
+                    <saga compensation="direct:compensate" completion="direct:complete">
+                        <to uri="direct:action"/>
+                    </saga>
+                </route>
+            </camelContext>
+            """));
+    }
+
+    /**
+     * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_saga_eip">Saga EIP</a>
+     */
+    @Test
+    void sagaEipYaml() {
+        //language=yaml
+        rewriteRun(yaml(
+          """
+            - route:
+                from:
+                  uri: direct:start
+                steps:
+                  - saga:
+                      compensation:
+                        uri: direct:compensate
+                      completion:
+                        uri: direct:complete
+                      steps:
+                        - to:
+                            uri: direct:action
+            """,
+          """
+            - route:
+                from:
+                  uri: direct:start
+                steps:
+                  - saga:
+                      compensation: direct:compensate
+                      completion: direct:complete
+                      steps:
+                        - to:
+                            uri: direct:action
+            """));
+    }
+
+    /**
+     * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_yaml_dsl">YAML DSL</a>
+     */
+    @Test
+    void yamlRoutePolicyRename() {
+        //language=yaml
+        rewriteRun(yaml(
+          """
+            - route:
+                id: myRoute
+                routePolicy: myPolicy
+                from:
+                  uri: direct:start
+                steps:
+                  - to:
+                      uri: mock:result
+            """,
+          """
+            - route:
+                id: myRoute
+                routePolicyRef: myPolicy
+                from:
+                  uri: direct:start
+                steps:
+                  - to:
+                      uri: mock:result
+            """));
+    }
+
+    /**
+     * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_test_infra">camel-test-infra</a>
+     */
+    @Test
+    void testInfraTestJarRemoval() {
+        //language=xml
+        rewriteRun(spec -> spec.recipe(new Pom419TestInfraRecipe()),
+          pomXml(
+          """
+            <project>
+                <groupId>com.example</groupId>
+                <artifactId>test-project</artifactId>
+                <version>1.0</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.camel</groupId>
+                        <artifactId>camel-test-infra-kafka</artifactId>
+                        <version>4.18.0</version>
+                        <type>test-jar</type>
+                        <scope>test</scope>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.apache.camel</groupId>
+                        <artifactId>camel-test-infra-common</artifactId>
+                        <version>4.18.0</version>
+                        <type>test-jar</type>
+                        <scope>test</scope>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.apache.camel</groupId>
+                        <artifactId>camel-core</artifactId>
+                        <version>4.18.0</version>
+                    </dependency>
+                </dependencies>
+            </project>
+            """,
+          """
+            <project>
+                <groupId>com.example</groupId>
+                <artifactId>test-project</artifactId>
+                <version>1.0</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.apache.camel</groupId>
+                        <artifactId>camel-test-infra-kafka</artifactId>
+                        <version>4.18.0</version>
+                        <scope>test</scope>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.apache.camel</groupId>
+                        <artifactId>camel-test-infra-common</artifactId>
+                        <version>4.18.0</version>
+                        <scope>test</scope>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.apache.camel</groupId>
+                        <artifactId>camel-core</artifactId>
+                        <version>4.18.0</version>
+                    </dependency>
+                </dependencies>
+            </project>
+            """));
     }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -116,10 +116,10 @@
         <jspecify-version>1.0.0</jspecify-version>
 
         <!-- versions for camel-spring-boot -->
-        <spring-boot-version>4.0.3</spring-boot-version>
-        <springframework-version>7.0.5</springframework-version>
-        <spring-security-version>7.0.3</spring-security-version>
-        <spring-batch-version>6.0.2</spring-batch-version>
+        <spring-boot-version>4.0.4</spring-boot-version>
+        <springframework-version>7.0.6</springframework-version>
+        <spring-security-version>7.0.4</spring-security-version>
+        <spring-batch-version>6.0.3</spring-batch-version>
 
         <!-- Should be aligned to quarkus-updates - https://github.com/quarkusio/quarkus-updates/blob/main/pom.xml#L64 -->
         <rewrite-recipe-bom.version>3.24.0</rewrite-recipe-bom.version>

--- a/pom.xml
+++ b/pom.xml
@@ -103,19 +103,23 @@
         <camel4.12-version>4.12.0</camel4.12-version>
         <camel4.14-version>4.14.0</camel4.14-version>
         <camel4.17-version>4.17.0</camel4.17-version>
+        <camel4.18-version>4.18.0</camel4.18-version>
 
         <camel4.10-lts-version>4.10.6</camel4.10-lts-version>
-        <camel-latest-version>4.18.0</camel-latest-version>
+        <camel-latest-version>4.19.0</camel-latest-version>
 
         <camel-version>${project.version}</camel-version>
         <camel-spring-boot-version>${project.version}</camel-spring-boot-version>
 
-        <!-- other versions used by the tests -->
+        <!-- versions for OpenRewrite dependencies -->
         <tahu-version>1.0.18</tahu-version>
+        <jspecify-version>1.0.0</jspecify-version>
 
         <!-- versions for camel-spring-boot -->
-        <spring-boot-version>3.5.10</spring-boot-version>
-        <springframework-version>6.2.15</springframework-version>
+        <spring-boot-version>4.0.3</spring-boot-version>
+        <springframework-version>7.0.5</springframework-version>
+        <spring-security-version>7.0.3</spring-security-version>
+        <spring-batch-version>6.0.2</spring-batch-version>
 
         <!-- Should be aligned to quarkus-updates - https://github.com/quarkusio/quarkus-updates/blob/main/pom.xml#L64 -->
         <rewrite-recipe-bom.version>3.24.0</rewrite-recipe-bom.version>

--- a/release_notes.adoc
+++ b/release_notes.adoc
@@ -1,5 +1,58 @@
 = Camel Upgrade Recipes - Release notes
 
+== 4.19.0
+
+=== Summary
+
+This is a release supporting Camel, Camel Quarkus and Camel Spring Boot 4.19.0 with the required upgrade recipes (described by the https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html[migration guide]).
+
+=== Migration coverage
+
+The following table lists migration topics and indicates the level of coverage (full, partial, or not covered), along with additional comments.
+
+[%autowidth,stripes=hover]
+|===
+| Migration | Coverage | Comment
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_bom[camel-bom] |  ✅ Full | Automatically migrated.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_cloud_removal[camel-cloud and serviceCall EIP] |  ✅ Full | Automatically migrated.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_pqc_tls_auto_configuration[PQC TLS Auto-Configuration] | ❌ None | Automatic configuration, no migration needed.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_errorregistry[Errorregistry] | ❌ None | Addition of a new SPI, no migration needed.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_saga_eip[Saga EIP] |  ✅ Full | XML and YAML DSL automatically migrated. Java DSL not affected.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_platform_http_main[camel-platform-http-main] | ❌ None | Configuration change requires manual review.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_csimple_deprecation[camel-csimple (deprecation)] | ❌ None | Deprecated module. Not supported by the migration tool.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_simple[camel-simple] | ❌ None | Syntax change requires manual code review.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_test_infra[camel-test-infra] | ✅ Full | Automatically migrated.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_yaml_io_camel_xml_io[camel-yaml-io / camel-xml-io] | ✅ Full | Automatically migrated.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_jackson_3_components[Jackson 3 components] | ❌ None | Component addition, no migration required.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_test_junit6_camel_test_main_junit6_camel_test_spring_junit6[camel-test-junit6, camel-test-main-junit6, camel-test-spring-junit6] | ❌ None | Optional migration.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_jbang[camel-jbang] | ❌ None | Configuration change requires manual review.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_groovy[camel-groovy] | ❌ None | External library upgrade requires manual testing.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_groovy_xml[camel-groovy-xml] | ✅ Full | Automatically migrated.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_kafka[camel-kafka] | ❌ None | External library upgrade with behavior changes. Requires manual review.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_google_pubsub_lite[camel-google-pubsub-lite] | ❌ None | Component removal requires manual migration.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_json_patch[camel-json-patch] | ❌ None |  Deprecated module. Not supported by the migration tool.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_mail[camel-mail] | ❌ None | Automatic behavior change, no code migration needed.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_file_camel_aws2_s3_camel_ibm_cos[camel-file / camel-aws2-s3 / camel-ibm-cos] | ❌ None | Behavior change, no migration required.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_openapi_java[camel-openapi-java] | ❌ None | Configuration change requires manual review.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_arangodb[camel-arangodb] | ❌ None | Configuration change requires manual review.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_as2[camel-as2] | ❌ None | API changes require manual code updates.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_couchbase[camel-couchbase] | ❌ None | Configuration change requires manual review.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_debezium[camel-debezium] | ❌ None | External library upgrade requires manual testing.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_mail_2[camel-mail] | ❌ None | Automatic behavior change, no code migration needed.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_ftp[camel-ftp] | ❌ None | Module extraction may require dependency addition for custom implementations.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_jsch_upgrade[JSch upgrade] | ❌ None | External library upgrade requires manual testing.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_openssh_certificate_authentication[OpenSSH certificate authentication] | ❌ None | New feature, no automated migration required.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_azure_credentialtype_standardization[camel-azure (CredentialType standardization)] | ❌ None | Enum deprecation. No automatic migration required.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_quickfixj[camel-quickfix] | ❌ None | External library upgrade requires manual testing.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_ssh[camel-ssh] | ❌ None | New properties available, no migration required.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_json_validator[camel-json-validator] | ❌ None | External library upgrade requires manual code updates.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_mdc_older_logic_deprecation[MDC older logic (Deprecation)] | ❌ None | Configuration deprecation requires manual migration.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_splunk_deprecation[camel-splunk (Deprecation)] | ❌ None | Component deprecation requires manual migration decision.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_tracing_deprecation[camel-tracing (Deprecation)] | ❌ None | Component deprecation requires manual migration decision.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_zeebe_deprecation[camel-zeebe (Deprecation)] | ❌ None | Deprecated component requires manual migration to camel-camunda.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_removed_components[Removed Components] | ✅ Full | Component removal: Automatically migrated.
+|===
+
 == 4.18.0
 
 === Summary
@@ -16,7 +69,7 @@ The following table lists migration topics and indicates the level of coverage (
 | https://camel.apache.org/manual/camel-4x-upgrade-guide-4_18.html#_camel_simple[camel-simple] |  ❌ None | Not supported by the migration tool.
 | https://camel.apache.org/manual/camel-4x-upgrade-guide-4_18.html#_camel_file[camel-file] | ❌ None | Not supported by the migration tool.
 | https://camel.apache.org/manual/camel-4x-upgrade-guide-4_18.html#_camel_docling[camel-docling] | ❌ None | Not supported by the migration tool.
-| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_18.html#_camel_qdrant[camel-qdrant] | ✅ Full todo    | Automatically migrated.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_18.html#_camel_qdrant[camel-qdrant] | ✅ Full | Automatically migrated.
 | https://camel.apache.org/manual/camel-4x-upgrade-guide-4_18.html#_camel_tahu[camel-tahu] | ⚠️ Partial | Tool renames handlers to MultiHostApplicationEventHandler. Other API changes are not covered.
 | https://camel.apache.org/manual/camel-4x-upgrade-guide-4_18.html#_camel_platform_http_vertx_and_rest_dsl_contract_first[camel-platform-http-vertx and Rest DSL contract-first] | ❌ None | Not supported by the migration tool.
 | https://camel.apache.org/manual/camel-4x-upgrade-guide-4_18.html#_component_deprecation[Component deprecation] | ❌ None | Not supported by the migration tool.

--- a/release_notes.adoc
+++ b/release_notes.adoc
@@ -1,5 +1,58 @@
 = Camel Upgrade Recipes - Release notes
 
+== 4.19.0
+
+=== Summary
+
+This is a release supporting Camel, Camel Quarkus and Camel Spring Boot 4.19.0 with the required upgrade recipes (described by the https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html[migration guide]).
+
+=== Migration coverage
+
+The following table lists migration topics and indicates the level of coverage (full, partial, or not covered), along with additional comments.
+
+[%autowidth,stripes=hover]
+|===
+| Migration | Coverage | Comment
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_bom[camel-bom] | ❌ None | Module removal requires manual dependency update.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_cloud_and_servicecall_eip[camel-cloud and serviceCall EIP] | ❌ None | Component removal requires manual migration.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_pqc_tls_auto_configuration[PQC TLS Auto-Configuration] | ❌ None | Automatic configuration, no migration needed.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_wiretap_eip[WireTap EIP] | ✅ Full | Automatically migrated.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_saga_eip[Saga EIP] |  ✅ Full | XML and YAML DSL automatically migrated. Java DSL not affected.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_platform_http_main[camel-platform-http-main] | ❌ None | Configuration change requires manual review.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_csimple_language[csimple language] | ❌ None | Language deprecation requires manual migration.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_simple_language[Simple language] | ❌ None | Syntax change requires manual code review.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_test_infra[camel-test-infra] | ✅ Full | Automatically migrated.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_yaml_dsl[YAML DSL routePolicy] | ✅ Full | Automatically migrated.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_route_eip_option_ordering[Route/EIP option ordering] | ❌ None | Output format change, no code migration needed.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_jackson_3[Jackson 3] | ❌ None | Optional component addition, no migration required.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_junit_5_to_junit_6[JUnit 5 to JUnit 6] | ❌ None | Optional migration.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_jbang[camel-jbang] | ❌ None | Configuration change requires manual review.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_groovy[Groovy] | ❌ None | External library upgrade requires manual testing.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_groovy_xml[camel-groovy-xml] | ✅ Full | Automatically migrated.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_kafka[Kafka] | ❌ None | External library upgrade with behavior changes requires manual review.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_google_pubsub_lite[camel-google-pubsub-lite] | ❌ None | Component removal requires manual migration.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_mail[camel-mail] | ❌ None | Automatic behavior change, no code migration needed.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_default_inprogressrepository[Default InProgressRepository] | ❌ None | Behavior change, no migration required.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_openapi_java[camel-openapi-java] | ❌ None | Configuration change requires manual review.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_arangodb[camel-arangodb] | ❌ None | Configuration change requires manual review.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_as2[camel-as2] | ❌ None | API changes require manual code updates.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_couchbase[camel-couchbase] | ❌ None | Configuration change requires manual review.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_debezium[Debezium] | ❌ None | External library upgrade requires manual testing.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_mail_sender[camel-mail custom sender] | ❌ None | Automatic behavior change, no code migration needed.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_ftp_common[camel-ftp-common] | ❌ None | Module extraction may require dependency addition for custom implementations.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_jsch[JSch] | ❌ None | External library upgrade requires manual testing.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_openssh_certificate[OpenSSH Certificate] | ❌ None | New feature, no migration required.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_azure_credentialtype[Azure CredentialType] | ❌ None | Optional migration for import standardization.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_quickfixj[QuickFixJ] | ❌ None | External library upgrade requires manual testing.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_ssh[SSH] | ❌ None | New properties available, no migration required.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_json_validator[JSON Validator] | ❌ None | External library upgrade requires manual code updates.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_mdc_logging[MDC Logging] | ❌ None | Configuration deprecation requires manual migration.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_splunk[camel-splunk] | ❌ None | Component deprecation requires manual migration decision.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_tracing[camel-tracing] | ❌ None | Component deprecation requires manual migration decision.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_zeebe[camel-zeebe] | ❌ None | Optional migration to camel-camunda.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_removed_components[Removed Components] | ❌ None | Component removal requires manual migration.
+|===
+
 == 4.18.0
 
 === Summary


### PR DESCRIPTION
Upgrade recipes to camel 4.19.0

I added plain camel recipes for migratio to camel 4.19.0 (followin https://raw.githubusercontent.com/apache/camel/refs/heads/main/docs/user-manual/modules/ROOT/pages/camel-4x-upgrade-guide-4_19.adoc

@cunningt I went throught the branch https://github.com/apache/camel-upgrade-recipes/tree/419updates and i tried to reuse most of the code. Although I'm not sure if all the version upgrades related to spring-boot are necessary. (like this [commit](https://github.com/apache/camel-upgrade-recipes/commit/ce3086169ffd0da3317af2dc2b49696349c9beb9)) Can not we use an openrewrite recipe for upgrading to latest spring-boot (like https://docs.openrewrite.org/recipes/java/spring/boot4/upgradespringboot_4_0-community-edition)?
Then I removed some camel-* version migrations which are not necessary in `4.19.yaml` recipe (they are part of `latest.yaml`)

TBH I'm not sure whether I missed something which is crucial for the migration to camel 4.19.0 from your branch. My I ask you for a review of this PR?

I oponed it as a draft, if anything more is missing, i can rebase my commit over any other commit, if needed.

@Croway FYI