### PR TITLE
Limit YamlDsl413Recipe to Camel YAML DSL files

### DIFF
--- a/camel-spring-boot-upgrade-recipes/src/test/java/org/apache/camel/upgrade/springboot/CamelSpringBoot413Test.java
+++ b/camel-spring-boot-upgrade-recipes/src/test/java/org/apache/camel/upgrade/springboot/CamelSpringBoot413Test.java
@@ -82,7 +82,7 @@ class CamelSpringBoot413Test implements RewriteTest {
                             name: 'Foo'
                           routecontroller.backOffMultiplier: 5
                           routecontroller.backOffDelay: true
-                          main.runController: something
+                          main.run-controller: something
                         another:
                           ignored:
                             property: true

--- a/camel-spring-boot-upgrade-recipes/src/test/java/org/apache/camel/upgrade/springboot/CamelSpringBoot413Test.java
+++ b/camel-spring-boot-upgrade-recipes/src/test/java/org/apache/camel/upgrade/springboot/CamelSpringBoot413Test.java
@@ -60,9 +60,9 @@ class CamelSpringBoot413Test implements RewriteTest {
     @Test
     void yamlFile() {
         rewriteRun(
-                //both org.apache.camel.upgrade.camel413.CamelSpringBootMigrationRecipe and
-                // org.apache.camel.upgrade.UpdateCamelSpringBootPropertiesAndYamlKeys modifies this properties
-                spec -> spec.expectedCyclesThatMakeChanges(2),
+                //only org.apache.camel.upgrade.UpdateCamelSpringBootPropertiesAndYamlKeys modifies this file;
+                // YamlDsl413Recipe is gated on Camel YAML DSL root keys and does not apply to Spring Boot application.yaml
+                spec -> spec.expectedCyclesThatMakeChanges(1),
             yaml(
                     """
                       camel:

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel413/YamlDsl413Recipe.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel413/YamlDsl413Recipe.java
@@ -21,9 +21,14 @@ import lombok.Value;
 import org.apache.camel.upgrade.AbstractCamelYamlVisitor;
 import org.apache.camel.upgrade.RecipesUtil;
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
+import org.openrewrite.marker.SearchResult;
+import org.openrewrite.yaml.YamlIsoVisitor;
 import org.openrewrite.yaml.tree.Yaml;
+
+import java.util.Set;
 
 /**
  * <p>
@@ -34,6 +39,19 @@ import org.openrewrite.yaml.tree.Yaml;
 @EqualsAndHashCode(callSuper = false)
 @Value
 public class YamlDsl413Recipe extends Recipe {
+
+    // Root-level keys that identify a YAML document as Camel YAML DSL,
+    // so the rewrite does not touch unrelated YAML (Kubernetes, GitHub Actions, Helm, etc.).
+    private static final Set<String> CAMEL_DSL_ROOT_KEYS = Set.of(
+            "route", "routes", "from", "rest", "beans",
+            "route-configuration", "routeConfiguration",
+            "route-template", "routeTemplate",
+            "templated-route", "templatedRoute",
+            "rest-configuration", "restConfiguration",
+            "error-handler", "errorHandler",
+            "on-exception", "onException",
+            "intercept", "intercept-from", "interceptFrom",
+            "intercept-send-to-endpoint", "interceptSendToEndpoint");
 
     @Override
     public String getDisplayName() {
@@ -48,7 +66,17 @@ public class YamlDsl413Recipe extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
 
-        return new AbstractCamelYamlVisitor() {
+        TreeVisitor<?, ExecutionContext> camelYamlDslCheck = new YamlIsoVisitor<ExecutionContext>() {
+            @Override
+            public Yaml.Document visitDocument(Yaml.Document document, ExecutionContext ctx) {
+                if (hasCamelRootKey(document.getBlock())) {
+                    return SearchResult.found(document);
+                }
+                return document;
+            }
+        };
+
+        return Preconditions.check(camelYamlDslCheck, new AbstractCamelYamlVisitor() {
 
             @Override
             protected void clearLocalCache() {
@@ -77,7 +105,20 @@ public class YamlDsl413Recipe extends Recipe {
                 return e;
             }
 
-        };
+        });
+    }
+
+    private static boolean hasCamelRootKey(Yaml.Block block) {
+        if (block instanceof Yaml.Mapping) {
+            return ((Yaml.Mapping) block).getEntries().stream()
+                    .anyMatch(entry -> CAMEL_DSL_ROOT_KEYS.contains(entry.getKey().getValue()));
+        }
+        if (block instanceof Yaml.Sequence) {
+            return ((Yaml.Sequence) block).getEntries().stream()
+                    .map(Yaml.Sequence.Entry::getBlock)
+                    .anyMatch(YamlDsl413Recipe::hasCamelRootKey);
+        }
+        return false;
     }
 
 }

--- a/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelUpdate413Test.java
+++ b/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelUpdate413Test.java
@@ -79,6 +79,50 @@ public class CamelUpdate413Test implements RewriteTest {
     }
 
     /**
+     * Non-Camel YAML (GitHub Actions workflow, Kubernetes manifest) must not be rewritten
+     * even when it contains kebab-case keys.
+     */
+    @Test
+    void yamlDslLeavesUnrelatedYamlAlone() {
+        rewriteRun(
+          //language=yaml
+          yaml(
+            """
+              name: CI
+              on:
+                push:
+                  branches: [main]
+              jobs:
+                build:
+                  runs-on: ubuntu-latest
+                  steps:
+                    - uses: actions/checkout@v4
+                    - uses: actions/setup-java@v4
+                      with:
+                        distribution: zulu
+                        java-version: '17'
+              """),
+          //language=yaml
+          yaml(
+            """
+              apiVersion: apps/v1
+              kind: Deployment
+              metadata:
+                name: my-app
+              spec:
+                replicas: 1
+                selector:
+                  match-labels:
+                    app: my-app
+                template:
+                  spec:
+                    containers:
+                      - name: app
+                        image-pull-policy: IfNotPresent
+              """));
+    }
+
+    /**
      * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_13.html#_camel_http">camel-http</a>
      */
     @Test


### PR DESCRIPTION
Previously the recipe rewrote kebab-case keys in every YAML file on the classpath, including GitHub Actions workflows, Kubernetes manifests and other unrelated YAML. Add a content-based precondition that only triggers the rewrite when a document's root block contains a known Camel YAML DSL key (route, from, rest, beans, route-configuration, etc.).
