### PR TITLE
Upgrade to Camel 4.20.0

### DIFF
--- a/camel-spring-boot-upgrade-recipes/pom.xml
+++ b/camel-spring-boot-upgrade-recipes/pom.xml
@@ -23,7 +23,7 @@
         <groupId>org.apache.camel.upgrade</groupId>
         <artifactId>camel-parent-upgrade-recipes</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>4.19.0-SNAPSHOT</version>
+        <version>4.20.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-spring-boot-upgrade-recipes</artifactId>

--- a/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/4.20.yaml
+++ b/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/4.20.yaml
@@ -1,0 +1,24 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.apache.camel.upgrade.camel420.CamelSpringBootMigrationRecipe
+displayName: Migrates Camel Spring Boot applications to Camel Spring Boot 4.20
+description: Migrates Camel Spring Boot applications to Camel Spring Boot 4.20.
+recipeList:
+  - org.apache.camel.upgrade.camel419.CamelSpringBootMigrationRecipe
+  - org.apache.camel.upgrade.camel420.CamelMigrationRecipe

--- a/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/latest.yaml
+++ b/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/latest.yaml
@@ -21,7 +21,7 @@ displayName: Migrate to Apache Camel Spring Boot @camel-latest-version@
 description: >- 
   Migrate applications to Apache Camel Spring Boot @camel-latest-version@ and Spring Boot @spring-boot-version@
 recipeList:
-  - org.apache.camel.upgrade.camel419.CamelSpringBootMigrationRecipe
+  - org.apache.camel.upgrade.camel420.CamelSpringBootMigrationRecipe
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: '*camel*'
       artifactId: 'camel-spring-boot-bom'

--- a/camel-upgrade-recipes/pom.xml
+++ b/camel-upgrade-recipes/pom.xml
@@ -23,7 +23,7 @@
         <groupId>org.apache.camel.upgrade</groupId>
         <artifactId>camel-parent-upgrade-recipes</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>4.19.0-SNAPSHOT</version>
+        <version>4.20.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-upgrade-recipes</artifactId>

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/RecipesUtil.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/RecipesUtil.java
@@ -315,4 +315,29 @@ public class RecipesUtil {
         return null;
     }
 
+    /**
+     * Transform a string using the provided pattern and replacement.
+     *
+     * @param value The original string
+     * @param pattern The compiled regex pattern to match
+     * @param replacement The replacement string using ${1}, ${2}, etc. for capturing groups
+     * @return Optional containing the transformed string, or empty if the pattern doesn't match
+     */
+    public static Optional<String> transform(String value, Pattern pattern, String replacement) {
+        Matcher matcher = pattern.matcher(value);
+        if (!matcher.matches()) {
+            return Optional.empty();
+        }
+
+        String result = replacement;
+
+        // Replace all ${n} placeholders with corresponding capturing groups
+        for (int i = 1; i <= matcher.groupCount(); i++) {
+            String groupValue = matcher.group(i);
+            // Replace with group value, or empty string if group is null
+            result = result.replace("${" + i + "}", groupValue != null ? groupValue : "");
+        }
+
+        return Optional.of(result);
+    }
 }

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/customRecipes/ChangeComponentUriRecipe.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/customRecipes/ChangeComponentUriRecipe.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.upgrade.customRecipes;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.RequiredArgsConstructor;
+import org.apache.camel.upgrade.customRecipes.internal.ChangeJavaComponentUriRecipe;
+import org.apache.camel.upgrade.customRecipes.internal.ChangeXmlComponentUriRecipe;
+import org.apache.camel.upgrade.customRecipes.internal.ChangeYamlComponentUriRecipe;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Option;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Composite recipe that transforms component URIs across all DSL types (Java, XML, YAML).
+ * <p>
+ * This recipe wraps the three DSL-specific recipes so users only need to specify
+ * the URI pattern and replacement once, and all DSL types are handled automatically.
+ * <p>
+ * Example usage in YAML:
+ * <pre>
+ * - org.apache.camel.upgrade.customRecipes.ChangeComponentUriRecipe:
+ *     uriPattern: "^pulsar:((persistent|non-persistent)://([^/]+)/([^/]+)/([^/]+)/(.+))$"
+ *     replacement: "pulsar:${2}://${3}/${5}/${6}"
+ * </pre>
+ * <p>
+ * This will transform Pulsar URIs in Java code, XML DSL, and YAML DSL all at once.
+ */
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
+@AllArgsConstructor
+public class ChangeComponentUriRecipe extends Recipe {
+
+    @Option(
+        displayName = "URI pattern",
+        description = "Regular expression to match the component URI. Use capturing groups for parts to preserve.",
+        example = "^pulsar:((persistent|non-persistent)://([^/]+)/([^/]+)/([^/]+)/(.+))$"
+    )
+    public String uriPattern;
+
+    @Option(
+        displayName = "Replacement",
+        description = "Replacement string using ${1}, ${2}, etc. to reference capturing groups from the pattern.",
+        example = "pulsar:${2}://${3}/${5}/${6}"
+    )
+    public String replacement;
+
+    @Override
+    public String getDisplayName() {
+        return "Change Camel component URI across all DSLs";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Transforms component URIs using regular expressions with capturing groups. " +
+               "Automatically handles Java, XML DSL, and YAML DSL.";
+    }
+
+    @Override
+    public List<Recipe> getRecipeList() {
+        List<Recipe> recipes = new ArrayList<>();
+
+        // Apply transformation to all three DSL types
+        recipes.add(new ChangeJavaComponentUriRecipe(uriPattern, replacement));
+        recipes.add(new ChangeXmlComponentUriRecipe(uriPattern, replacement));
+        recipes.add(new ChangeYamlComponentUriRecipe(uriPattern, replacement));
+
+        return recipes;
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        // This is a composite recipe - the actual work is done by the sub-recipes
+        return TreeVisitor.noop();
+    }
+}

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/customRecipes/internal/ChangeJavaComponentUriRecipe.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/customRecipes/internal/ChangeJavaComponentUriRecipe.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.upgrade.customRecipes.internal;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.RequiredArgsConstructor;
+import org.apache.camel.upgrade.AbstractCamelJavaVisitor;
+import org.apache.camel.upgrade.RecipesUtil;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Option;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.tree.J;
+import org.openrewrite.java.tree.JavaType;
+
+import java.util.regex.Pattern;
+
+/**
+ * Transform component URIs in Java code using regexp with capturing groups.
+ */
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
+@AllArgsConstructor
+public class ChangeJavaComponentUriRecipe extends Recipe {
+
+    @Option(
+        displayName = "URI pattern",
+        description = "Regular expression to match the component URI. Use capturing groups for parts to preserve.",
+        example = "^pulsar:((persistent|non-persistent)://([^/]+)/([^/]+)/([^/]+)/(.+))$"
+    )
+    public String uriPattern;
+
+    @Option(
+        displayName = "Replacement",
+        description = "Replacement string using ${1}, ${2}, etc. to reference capturing groups from the pattern.",
+        example = "pulsar:${2}://${3}/${5}/${6}"
+    )
+    public String replacement;
+
+    @Override
+    public String getDisplayName() {
+        return "Change Camel component URI in Java";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Transforms component URIs in Java code using regular expressions with capturing groups.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        Pattern pattern = Pattern.compile(uriPattern);
+
+        return new AbstractCamelJavaVisitor() {
+            @Override
+            protected J.Literal doVisitLiteral(J.Literal literal, ExecutionContext ctx) {
+                J.Literal l = super.doVisitLiteral(literal, ctx);
+
+                if (JavaType.Primitive.String == l.getType() && l.getValue() != null) {
+                    String value = (String) l.getValue();
+                    return RecipesUtil.transform(value, pattern, replacement)
+                            .map(newValue -> RecipesUtil.createStringLiteral(newValue).withPrefix(literal.getPrefix()))
+                            .orElse(l);
+                }
+
+                return l;
+            }
+        };
+    }
+}

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/customRecipes/internal/ChangeXmlComponentUriRecipe.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/customRecipes/internal/ChangeXmlComponentUriRecipe.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.upgrade.customRecipes.internal;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.RequiredArgsConstructor;
+import org.apache.camel.upgrade.AbstractCamelXmlVisitor;
+import org.apache.camel.upgrade.RecipesUtil;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Option;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.xml.XPathMatcher;
+import org.openrewrite.xml.tree.Xml;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+/**
+ * Transform component URIs in XML DSL using regexp with capturing groups.
+ */
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
+@AllArgsConstructor
+public class ChangeXmlComponentUriRecipe extends Recipe {
+
+    private static final XPathMatcher FROM_MATCHER = new XPathMatcher("//route/from");
+    private static final XPathMatcher TO_MATCHER = new XPathMatcher("//route/to");
+
+    @Option(
+        displayName = "URI pattern",
+        description = "Regular expression to match the component URI. Use capturing groups for parts to preserve.",
+        example = "^pulsar:((persistent|non-persistent)://([^/]+)/([^/]+)/([^/]+)/(.+))$"
+    )
+    public String uriPattern;
+
+    @Option(
+        displayName = "Replacement",
+        description = "Replacement string using ${1}, ${2}, etc. to reference capturing groups from the pattern.",
+        example = "pulsar:${2}://${3}/${5}/${6}"
+    )
+    public String replacement;
+
+    @Override
+    public String getDisplayName() {
+        return "Change Camel component URI in XML DSL";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Transforms component URIs in XML DSL using regular expressions with capturing groups.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        Pattern pattern = Pattern.compile(uriPattern);
+
+        return new AbstractCamelXmlVisitor() {
+            @Override
+            public Xml.Tag doVisitTag(Xml.Tag tag, ExecutionContext ctx) {
+                Xml.Tag t = super.doVisitTag(tag, ctx);
+
+                if (FROM_MATCHER.matches(getCursor()) || TO_MATCHER.matches(getCursor())) {
+                    return transformXmlUri(t, pattern, replacement);
+                }
+
+                return t;
+            }
+        };
+    }
+
+    private static Xml.Tag transformXmlUri(Xml.Tag tag, Pattern pattern, String replacement) {
+        List<Xml.Attribute> attributes = new ArrayList<>(tag.getAttributes());
+        Optional<Xml.Attribute> uriAttr = attributes.stream()
+                .filter(a -> "uri".equals(a.getKey().getName()))
+                .findFirst();
+
+        if (uriAttr.isPresent()) {
+            String originalUri = uriAttr.get().getValue().getValue();
+            return RecipesUtil.transform(originalUri, pattern, replacement)
+                    .map(newUri -> {
+                        attributes.remove(uriAttr.get());
+                        attributes.add(uriAttr.get().withValue(uriAttr.get().getValue().withValue(newUri)));
+                        return tag.withAttributes(attributes);
+                    })
+                    .orElse(tag);
+        }
+
+        return tag;
+    }
+}

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/customRecipes/internal/ChangeYamlComponentUriRecipe.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/customRecipes/internal/ChangeYamlComponentUriRecipe.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.upgrade.customRecipes.internal;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.RequiredArgsConstructor;
+import org.apache.camel.upgrade.AbstractCamelYamlVisitor;
+import org.apache.camel.upgrade.RecipesUtil;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Option;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.yaml.JsonPathMatcher;
+import org.openrewrite.yaml.tree.Yaml;
+
+import java.util.regex.Pattern;
+
+/**
+ * Transform component URIs in YAML DSL using regexp with capturing groups.
+ */
+@EqualsAndHashCode(callSuper = false)
+@RequiredArgsConstructor
+@AllArgsConstructor
+public class ChangeYamlComponentUriRecipe extends Recipe {
+
+    private static final JsonPathMatcher YAML_URI_MATCHER = new JsonPathMatcher("$..uri");
+
+    @Option(
+        displayName = "URI pattern",
+        description = "Regular expression to match the component URI. Use capturing groups for parts to preserve.",
+        example = "^pulsar:((persistent|non-persistent)://([^/]+)/([^/]+)/([^/]+)/(.+))$"
+    )
+    public String uriPattern;
+
+    @Option(
+        displayName = "Replacement",
+        description = "Replacement string using ${1}, ${2}, etc. to reference capturing groups from the pattern.",
+        example = "pulsar:${2}://${3}/${5}/${6}"
+    )
+    public String replacement;
+
+    @Override
+    public String getDisplayName() {
+        return "Change Camel component URI in YAML DSL";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Transforms component URIs in YAML DSL using regular expressions with capturing groups.";
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        Pattern pattern = Pattern.compile(uriPattern);
+
+        return new AbstractCamelYamlVisitor() {
+            @Override
+            protected void clearLocalCache() {
+                // Nothing to clear
+            }
+
+            @Override
+            public Yaml.Mapping.Entry doVisitMappingEntry(Yaml.Mapping.Entry entry, ExecutionContext ctx) {
+                Yaml.Mapping.Entry e = super.doVisitMappingEntry(entry, ctx);
+
+                // Check if this is a uri field
+                if (YAML_URI_MATCHER.matches(getCursor()) && e.getValue() instanceof Yaml.Scalar) {
+                    Yaml.Scalar scalar = (Yaml.Scalar) e.getValue();
+                    return RecipesUtil.transform(scalar.getValue(), pattern, replacement)
+                            .map(newValue -> e.withValue(scalar.withValue(newValue)))
+                            .orElse(e);
+                }
+
+                return e;
+            }
+        };
+    }
+}

--- a/camel-upgrade-recipes/src/main/resources/META-INF/rewrite/4.20.yaml
+++ b/camel-upgrade-recipes/src/main/resources/META-INF/rewrite/4.20.yaml
@@ -1,0 +1,56 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#####
+# Rules coming from https://camel.apache.org/manual/camel-4x-upgrade-guide-4_20.html
+#####
+
+#####
+# Update the Camel project from 4.19 to 4.20
+#####
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.apache.camel.upgrade.camel420.CamelMigrationRecipe
+displayName: Migrates `camel 4.19` application to `camel 4.20`
+description: Migrates `camel 4.19` application to `camel 4.20`.
+recipeList:
+  - org.apache.camel.upgrade.camel420.migratePulsarUris
+---
+# https://camel.apache.org/manual/camel-4x-upgrade-guide-4_20.html#_camel_pulsar
+# Migrate Pulsar URIs from V1 to V2 format (removes cluster segment)
+type: specs.openrewrite.org/v1beta/recipe
+name: org.apache.camel.upgrade.camel420.migratePulsarUris
+displayName: Migrate Pulsar component URIs from V1 to V2 format
+description: |
+  Apache Pulsar client upgraded from 4.1.3 to 4.2.0. Per PIP-457, V1 topic names are no longer supported.
+  Migrates from V1 format (persistent://tenant/cluster/namespace/topic) to V2 format (persistent://tenant/namespace/topic).
+  Removes the cluster segment. Only transforms URIs where the topic name does NOT contain slashes.
+  URIs with slashes in topic names are left unchanged to avoid ambiguity between V1 and V2 formats.
+  Works across Java, XML DSL, and YAML DSL.
+recipeList:
+  - org.apache.camel.upgrade.customRecipes.ChangeComponentUriRecipe:
+      uriPattern: "^pulsar:(persistent|non-persistent)://([^/]+)/([^/]+)/([^/]+)/([^/?]+)(\\?.*)?$"
+      replacement: "pulsar:${1}://${2}/${4}/${5}${6}"
+#        Example: pulsar:persistent://public/cluster1/default/my-topic?param=value
+#        Matches:
+#           ${1} = persistent        (persistence type)
+#           ${2} = public            (tenant)
+#           ${3} = cluster1          ← REMOVED in replacement (cluster - removed in V2)
+#           ${4} = default           (namespace)
+#           ${5} = my-topic          (topic name - no slashes allowed)
+#           ${6} = ?param=value      (query parameters - optional, empty if not present)
+

--- a/camel-upgrade-recipes/src/main/resources/META-INF/rewrite/latest.yaml
+++ b/camel-upgrade-recipes/src/main/resources/META-INF/rewrite/latest.yaml
@@ -20,6 +20,7 @@ name: org.apache.camel.upgrade.CamelMigrationRecipe
 displayName: Migrate to @camel-latest-version@
 description: Migrates Apache Camel application to @camel-latest-version@.
 recipeList:
+  - org.apache.camel.upgrade.camel420.CamelMigrationRecipe
   - org.apache.camel.upgrade.camel419.CamelMigrationRecipe
   - org.apache.camel.upgrade.camel418.CamelMigrationRecipe
   - org.apache.camel.upgrade.camel417.CamelMigrationRecipe

--- a/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelTestUtil.java
+++ b/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelTestUtil.java
@@ -55,7 +55,8 @@ public class CamelTestUtil {
         v4_16(4, 16, 0),
         v4_17(4, 17, 0),
         v4_18(4, 18, 0),
-        v4_19(4, 19, 0);
+        v4_19(4, 19, 0),
+        v4_20(4, 20, 0);
 
         private int major;
         private int minor;

--- a/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelUpdate413Test.java
+++ b/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelUpdate413Test.java
@@ -101,7 +101,8 @@ public class CamelUpdate413Test implements RewriteTest {
                       with:
                         distribution: zulu
                         java-version: '17'
-              """),
+              """
+          ),
           //language=yaml
           yaml(
             """
@@ -119,7 +120,8 @@ public class CamelUpdate413Test implements RewriteTest {
                     containers:
                       - name: app
                         image-pull-policy: IfNotPresent
-              """));
+              """
+          ));
     }
 
     /**

--- a/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelUpdate419Test.java
+++ b/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelUpdate419Test.java
@@ -16,8 +16,10 @@
  */
 package org.apache.camel.upgrade;
 
-import org.apache.camel.upgrade.camel419.*;
+import org.apache.camel.upgrade.camel419.Pom419TestInfraRecipe;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.test.TypeValidation;
@@ -31,19 +33,26 @@ public class CamelUpdate419Test implements RewriteTest {
 
     @Override
     public void defaults(RecipeSpec spec) {
-        spec.recipeFromResources("org.apache.camel.upgrade.camel419.CamelMigrationRecipe")
+        CamelTestUtil.recipe(spec, CamelTestUtil.CamelVersion.v4_19)
                 .parser(CamelTestUtil.parserFromClasspath(CamelTestUtil.CamelVersion.v4_18,
-                        "camel-core-model", "camel-api"))
+                        "camel-core-model", "camel-api", "camel-qdrant", "camel-tahu", "tahu-host"))
                 .typeValidationOptions(TypeValidation.none());
     }
 
     /**
      * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_18.html#_camel_bom">camel-bom</a>
+     *
+     * This test verifies both the removal of camel-test dependency (4.19 specific)
+     * and version property upgrades. It combines the 4.19 migration recipe with
+     * the internal CamelToTheLatestRecipe for version upgrades.
      */
+    @DisabledIfSystemProperty(named = CamelTestUtil.PROPERTY_USE_RECIPE, matches = ".+")
+    @DocumentExample
     @Test
     void camelBom() {
         //language=xml
-        rewriteRun(pomXml(
+        rewriteRun(
+            pomXml(
                 """
                   <project>
                      <modelVersion>4.0.0</modelVersion>
@@ -92,7 +101,8 @@ public class CamelUpdate419Test implements RewriteTest {
                       </dependencies>
       
                   </project>
-                  """));
+                  """
+            ));
     }
 
     /**
@@ -157,27 +167,27 @@ public class CamelUpdate419Test implements RewriteTest {
             - route:
                 from:
                   uri: direct:start
-                steps:
-                  - saga:
-                      compensation:
-                        uri: direct:compensate
-                      completion:
-                        uri: direct:complete
-                      steps:
-                        - to:
-                            uri: direct:action
+                  steps:
+                    - saga:
+                        compensation:
+                          uri: direct:compensate
+                        completion:
+                          uri: direct:complete
+                        steps:
+                          - to:
+                              uri: direct:action
             """,
           """
             - route:
                 from:
                   uri: direct:start
-                steps:
-                  - saga:
-                      compensation: direct:compensate
-                      completion: direct:complete
-                      steps:
-                        - to:
-                            uri: direct:action
+                  steps:
+                    - saga:
+                        compensation: direct:compensate
+                        completion: direct:complete
+                        steps:
+                          - to:
+                              uri: direct:action
             """));
     }
 
@@ -185,8 +195,9 @@ public class CamelUpdate419Test implements RewriteTest {
     /**
      * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_test_infra">camel-test-infra</a>
      */
+    @DisabledIfSystemProperty(named = CamelTestUtil.PROPERTY_USE_RECIPE, matches = ".+")
     @Test
-    void testInfraTestJarRemoval() {
+    void infraTestJarRemoval() {
         //language=xml
         rewriteRun(spec -> spec.recipe(new Pom419TestInfraRecipe()),
                 pomXml(
@@ -243,7 +254,8 @@ public class CamelUpdate419Test implements RewriteTest {
                                   </dependency>
                               </dependencies>
                           </project>
-                          """));
+                          """
+                ));
     }
 
     /**
@@ -259,9 +271,9 @@ public class CamelUpdate419Test implements RewriteTest {
                 routePolicy: myPolicy
                 from:
                   uri: direct:start
-                steps:
-                  - to:
-                      uri: mock:result
+                  steps:
+                    - to:
+                        uri: mock:result
             """,
           """
             - route:
@@ -269,14 +281,15 @@ public class CamelUpdate419Test implements RewriteTest {
                 routePolicyRef: myPolicy
                 from:
                   uri: direct:start
-                steps:
-                  - to:
-                      uri: mock:result
+                  steps:
+                    - to:
+                        uri: mock:result
             """));
     }
     /**
      * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_18.html#_camel_bom">camel-bom</a>
      */
+    @DisabledIfSystemProperty(named = CamelTestUtil.PROPERTY_USE_RECIPE, matches = ".+")
     @Test
     void removedComponents() {
         //language=xml

--- a/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelUpdate420Test.java
+++ b/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelUpdate420Test.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.upgrade;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+import org.openrewrite.test.TypeValidation;
+
+import static org.openrewrite.java.Assertions.java;
+import static org.openrewrite.xml.Assertions.xml;
+import static org.openrewrite.yaml.Assertions.yaml;
+
+public class CamelUpdate420Test implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        CamelTestUtil.recipe(spec, CamelTestUtil.CamelVersion.v4_20)
+                .parser(CamelTestUtil.parserFromClasspath(CamelTestUtil.CamelVersion.v4_19,
+                        "camel-core-model", "camel-api", "camel-qdrant", "camel-tahu", "tahu-host"))
+                .typeValidationOptions(TypeValidation.none());
+    }
+
+    /**
+     * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_20.html#_camel_pulsar">camel-pulsar</a>
+     * Tests all Java DSL transformations
+     */
+    @DocumentExample
+    @Test
+    void pulsarJavaDsl() {
+        //language=java
+        rewriteRun(
+                // V1 persistent to V2
+                java(
+                        """
+                        import org.apache.camel.builder.RouteBuilder;
+
+                        public class MyRoute extends RouteBuilder {
+                            @Override
+                            public void configure() {
+                                // V1 persistent to V2 (simple topic name)
+                                from("pulsar:persistent://public/cluster1/default/my-topic")
+                                    .to("mock:result");
+                                // V1 non-persistent to V2
+                                from("pulsar:non-persistent://tenant1/cluster2/namespace1/topic1")
+                                    .to("mock:result");
+                                // V1 with query parameters
+                                from("pulsar:persistent://public/cluster1/default/my-topic?numberOfConsumers=5&subscriptionType=Shared")
+                                    .to("mock:result");
+                                // Topic with slashes - NOT transformed (ambiguous if V1 or V2)
+                                from("pulsar:persistent://public/cluster1/default/my-topic/sub-path")
+                                    .to("mock:result");
+                                // Topic with slashes and params - NOT transformed
+                                from("pulsar:persistent://tenant/cluster/ns/topic/path/more?subscriptionName=sub1")
+                                    .to("mock:result");
+                                // V2 format - unchanged
+                                from("pulsar:persistent://public/default/my-topic")
+                                    .to("mock:result");
+                                // Non-pulsar component - unchanged
+                                from("other-component:my-topic")
+                                    .to("mock:result");
+                            }
+                        }
+                        """,
+                        """
+                        import org.apache.camel.builder.RouteBuilder;
+
+                        public class MyRoute extends RouteBuilder {
+                            @Override
+                            public void configure() {
+                                // V1 persistent to V2 (simple topic name)
+                                from("pulsar:persistent://public/default/my-topic")
+                                    .to("mock:result");
+                                // V1 non-persistent to V2
+                                from("pulsar:non-persistent://tenant1/namespace1/topic1")
+                                    .to("mock:result");
+                                // V1 with query parameters
+                                from("pulsar:persistent://public/default/my-topic?numberOfConsumers=5&subscriptionType=Shared")
+                                    .to("mock:result");
+                                // Topic with slashes - NOT transformed (ambiguous if V1 or V2)
+                                from("pulsar:persistent://public/cluster1/default/my-topic/sub-path")
+                                    .to("mock:result");
+                                // Topic with slashes and params - NOT transformed
+                                from("pulsar:persistent://tenant/cluster/ns/topic/path/more?subscriptionName=sub1")
+                                    .to("mock:result");
+                                // V2 format - unchanged
+                                from("pulsar:persistent://public/default/my-topic")
+                                    .to("mock:result");
+                                // Non-pulsar component - unchanged
+                                from("other-component:my-topic")
+                                    .to("mock:result");
+                            }
+                        }
+                        """
+                )
+        );
+    }
+
+    /**
+     * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_20.html#_camel_pulsar">camel-pulsar</a>
+     * Tests all XML DSL transformations
+     */
+    @Test
+    void pulsarXmlDsl() {
+        //language=xml
+        rewriteRun(
+                xml(
+                        """
+                        <routes xmlns="http://camel.apache.org/schema/spring">
+                            <!-- V1 to V2 transformation -->
+                            <route id="pulsarRoute">
+                                <from uri="pulsar:persistent://public/cluster1/default/my-topic"/>
+                                <to uri="pulsar:non-persistent://tenant/cluster2/ns/topic1?subscriptionName=sub1"/>
+                                <to uri="mock:result"/>
+                            </route>
+                            <!-- Topic with slashes - NOT transformed (ambiguous) -->
+                            <route>
+                                <from uri="pulsar:persistent://tenant/cluster/namespace/topic/with/slashes?param=value"/>
+                            </route>
+                        </routes>
+                        """,
+                        """
+                        <routes xmlns="http://camel.apache.org/schema/spring">
+                            <!-- V1 to V2 transformation -->
+                            <route id="pulsarRoute">
+                                <from uri="pulsar:persistent://public/default/my-topic"/>
+                                <to uri="pulsar:non-persistent://tenant/ns/topic1?subscriptionName=sub1"/>
+                                <to uri="mock:result"/>
+                            </route>
+                            <!-- Topic with slashes - NOT transformed (ambiguous) -->
+                            <route>
+                                <from uri="pulsar:persistent://tenant/cluster/namespace/topic/with/slashes?param=value"/>
+                            </route>
+                        </routes>
+                        """
+                )
+        );
+    }
+
+    /**
+     * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_20.html#_camel_pulsar">camel-pulsar</a>
+     * Tests all YAML DSL transformations
+     */
+    @Test
+    void pulsarYamlDsl() {
+        //language=yaml
+        rewriteRun(
+                // V1 to V2 transformation
+                yaml(
+                        """
+                        - route:
+                            id: pulsarRoute
+                            from:
+                              uri: pulsar:persistent://public/cluster1/default/my-topic
+                              steps:
+                                - to:
+                                    uri: pulsar:non-persistent://tenant/cluster2/ns/topic1?subscriptionName=sub1
+                                - to:
+                                    uri: mock:result
+                        """,
+                        """
+                        - route:
+                            id: pulsarRoute
+                            from:
+                              uri: pulsar:persistent://public/default/my-topic
+                              steps:
+                                - to:
+                                    uri: pulsar:non-persistent://tenant/ns/topic1?subscriptionName=sub1
+                                - to:
+                                    uri: mock:result
+                        """
+                ),
+                // Topic with slashes - NOT transformed (ambiguous)
+                yaml(
+                        """
+                        - route:
+                            from:
+                              uri: pulsar:persistent://tenant/cluster/namespace/topic/with/slashes
+                        """
+                )
+        );
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     </parent>
 
     <groupId>org.apache.camel.upgrade</groupId>
-    <version>4.19.0-SNAPSHOT</version>
+    <version>4.20.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <artifactId>camel-parent-upgrade-recipes</artifactId>
 

--- a/release_notes.adoc
+++ b/release_notes.adoc
@@ -1,10 +1,10 @@
 = Camel Upgrade Recipes - Release notes
 
-== 4.19.0
+== 4.20.0
 
 === Summary
 
-This is a release supporting Camel, Camel Quarkus and Camel Spring Boot 4.19.0 with the required upgrade recipes (described by the https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html[migration guide]).
+This is a release supporting Camel, Camel Quarkus and Camel Spring Boot 4.20.0 with the required upgrade recipes (described by the https://camel.apache.org/manual/camel-4x-upgrade-guide-4_20.html[migration guide]).
 
 === Migration coverage
 
@@ -13,6 +13,10 @@ The following table lists migration topics and indicates the level of coverage (
 [%autowidth,stripes=hover]
 |===
 | Migration | Coverage | Comment
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_20.html#_camel_jbang[camel-jbang] | ❌ None | YAML DSL file naming convention change. Manual review required.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_20.html#_camel_exec[camel-exec] | ❌ None | Security change requiring explicit opt-in via `allowControlHeaders=true`. Manual configuration required.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_20.html#_camel_pulsar[camel-pulsar] | ⚠️ Partial | V1 to V2 topic URI format automatically migrated for simple topic names (without slashes). Removes cluster segment from URIs like `pulsar:persistent://tenant/cluster/namespace/topic`. URIs with slashes in topic names (e.g., `topic/sub-path`) are NOT transformed to avoid ambiguity between V1 and V2 formats - these require manual migration.
+| https://camel.apache.org/manual/camel-4x-upgrade-guide-4_20.html#_camel_oaipmh[camel-oaipmh] | ❌ None | New HTTP header parameter functionality. No migration needed.
 | https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_bom[camel-bom] |  ✅ Full | Automatically migrated.
 | https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_cloud_removal[camel-cloud and serviceCall EIP] |  ✅ Full | Automatically migrated.
 | https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_pqc_tls_auto_configuration[PQC TLS Auto-Configuration] | ❌ None | Automatic configuration, no migration needed.


### PR DESCRIPTION
Migration recipes for camel 4.19.0 -> 4.20.0

There were some small bugs in the tests for 4.19.0 - it is fixed now
The next release version will be 4.20.0, so the pom version are changed accordingly.
Both latest recipes are updated.