### PR TITLE
Aligned to the latest camel version + instruction for manual check b

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -59,6 +59,9 @@ This project is released as standard Apache Camel module.
 
 ⚠️ Check that the following versions are up-to-date!
 ```xml
+        <!-- versions for latest recipes, has to be kept aligned to the latest camel release -->
+        <camel-latest-version>4.20.0</camel-latest-version>
+
         <!-- versions for camel-spring-boot -->
         <spring-boot-version>3.5.10</spring-boot-version>
         <springframework-version>6.2.15</springframework-version>

--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,9 @@
         <camel4.18-version>4.18.0</camel4.18-version>
 
         <camel4.10-lts-version>4.10.6</camel4.10-lts-version>
-        <camel-latest-version>4.19.0</camel-latest-version>
+
+        <!-- versions for latest recipes, has to be kept aligned to the latest camel release -->
+        <camel-latest-version>4.20.0</camel-latest-version>
 
         <camel-version>${project.version}</camel-version>
         <camel-spring-boot-version>${project.version}</camel-spring-boot-version>


### PR DESCRIPTION
Sets latest camel version to 4.20.0 so 'latest.yaml' recipes would upgrade to the proper version.

And a simple note for manual check before the release is started (will be covered by automatic test - reported as https://github.com/apache/camel-upgrade-recipes/issues/97)