### PR TITLE
Revert version to 4.20.0-SNAPSHOT

### DIFF
--- a/camel-spring-boot-upgrade-recipes/pom.xml
+++ b/camel-spring-boot-upgrade-recipes/pom.xml
@@ -23,7 +23,7 @@
         <groupId>org.apache.camel.upgrade</groupId>
         <artifactId>camel-parent-upgrade-recipes</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>4.20.0</version>
+        <version>4.20.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-spring-boot-upgrade-recipes</artifactId>

--- a/camel-spring-boot-upgrade-recipes/pom.xml
+++ b/camel-spring-boot-upgrade-recipes/pom.xml
@@ -23,7 +23,7 @@
         <groupId>org.apache.camel.upgrade</groupId>
         <artifactId>camel-parent-upgrade-recipes</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>4.21.0-SNAPSHOT</version>
+        <version>4.20.0</version>
     </parent>
 
     <artifactId>camel-spring-boot-upgrade-recipes</artifactId>

--- a/camel-upgrade-recipes/pom.xml
+++ b/camel-upgrade-recipes/pom.xml
@@ -23,7 +23,7 @@
         <groupId>org.apache.camel.upgrade</groupId>
         <artifactId>camel-parent-upgrade-recipes</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>4.20.0</version>
+        <version>4.20.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>camel-upgrade-recipes</artifactId>

--- a/camel-upgrade-recipes/pom.xml
+++ b/camel-upgrade-recipes/pom.xml
@@ -23,7 +23,7 @@
         <groupId>org.apache.camel.upgrade</groupId>
         <artifactId>camel-parent-upgrade-recipes</artifactId>
         <relativePath>../pom.xml</relativePath>
-        <version>4.21.0-SNAPSHOT</version>
+        <version>4.20.0</version>
     </parent>
 
     <artifactId>camel-upgrade-recipes</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     </parent>
 
     <groupId>org.apache.camel.upgrade</groupId>
-    <version>4.21.0-SNAPSHOT</version>
+    <version>4.20.0</version>
     <packaging>pom</packaging>
     <artifactId>camel-parent-upgrade-recipes</artifactId>
 
@@ -74,7 +74,7 @@
         <connection>scm:git:http://gitbox.apache.org/repos/asf/camel-upgrade-recipes.git</connection>
         <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/camel-upgrade-recipes.git</developerConnection>
         <url>https://github.com/apache/camel-upgrade-recipes</url>
-        <tag>HEAD</tag>
+        <tag>4.20.0</tag>
     </scm>
     <issueManagement>
         <system>jira</system>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     </parent>
 
     <groupId>org.apache.camel.upgrade</groupId>
-    <version>4.20.0</version>
+    <version>4.20.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <artifactId>camel-parent-upgrade-recipes</artifactId>
 
@@ -74,7 +74,7 @@
         <connection>scm:git:http://gitbox.apache.org/repos/asf/camel-upgrade-recipes.git</connection>
         <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/camel-upgrade-recipes.git</developerConnection>
         <url>https://github.com/apache/camel-upgrade-recipes</url>
-        <tag>4.20.0</tag>
+        <tag>HEAD</tag>
     </scm>
     <issueManagement>
         <system>jira</system>


### PR DESCRIPTION
## Summary
- Reverts the two maven-release-plugin commits that bumped the version to 4.21.0-SNAPSHOT
- Restores version to 4.20.0-SNAPSHOT to align with the latest Camel 4.20.0 release

## Test plan
- [ ] Verify `pom.xml` version is `4.20.0-SNAPSHOT` across all modules
- [ ] Run `mvn clean install` to confirm build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)