### PR TITLE
JDK25 : add proc full to maven-compiler-plugin to support annotations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,6 +166,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${maven-compiler-plugin.version}</version>
+                <configuration>
+                    <proc>full</proc>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
         <spring-batch-version>6.0.3</spring-batch-version>
 
         <!-- Should be aligned to quarkus-updates - https://github.com/quarkusio/quarkus-updates/blob/main/pom.xml#L64 -->
-        <rewrite-recipe-bom.version>3.24.0</rewrite-recipe-bom.version>
+        <rewrite-recipe-bom.version>3.30.1</rewrite-recipe-bom.version>
 
         <lombok.version>1.18.42</lombok.version>
         <slf4j.version>1.7.36</slf4j.version>


### PR DESCRIPTION
- add `<proc>full</proc>` to maven-compiler-plugin so we can compile on JDK25.    
- upgrade rewrite recipe to support tests on JDK 25

Project is currently failing compile: 

> [INFO] Reactor Summary for Camel Parent Upgrades Recipes 4.21.0-SNAPSHOT:
> [INFO]
> [INFO] Camel Parent Upgrades Recipes ...................... SUCCESS [  0.453 s]
> [INFO] Camel Upgrades Recipes ............................. FAILURE [  1.026 s]
> [INFO] Camel Spring Boot Upgrades Recipes ................. SKIPPED
> [INFO] ------------------------------------------------------------------------
> [INFO] BUILD FAILURE
> [INFO] ------------------------------------------------------------------------
> [INFO] Total time:  1.537 s
> [INFO] Finished at: 2026-05-08T10:36:20-04:00
> [INFO] ------------------------------------------------------------------------
> [ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.15.0:compile (default-compile) on project camel-upgrade-recipes: Compilation failure: Compilation failure:
> [ERROR] /Users/tcunning/src/community/camel-upgrade-recipes/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/customRecipes/ChangeComponentUriRecipe.java:[83,21] constructor ChangeJavaComponentUriRecipe in class org.apache.camel.upgrade.customRecipes.internal.ChangeJavaComponentUriRecipe cannot be applied to given types;
> [ERROR]   required: no arguments
> [ERROR]   found:    java.lang.String,java.lang.String
> [ERROR]   reason: actual and formal argument lists differ in length
> [ERROR] /Users/tcunning/src/community/camel-upgrade-recipes/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/customRecipes/ChangeComponentUriRecipe.java:[84,21] constructor ChangeXmlComponentUriRecipe in class org.apache.camel.upgrade.customRecipes.internal.ChangeXmlComponentUriRecipe cannot be applied to given types;
> [ERROR]   required: no arguments
> [ERROR]   found:    java.lang.String,java.lang.String
> [ERROR]   reason: actual and formal argument lists differ in length
> [ERROR] /Users/tcunning/src/community/camel-upgrade-recipes/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/customRecipes/ChangeComponentUriRecipe.java:[85,21] constructor ChangeYamlComponentUriRecipe in class org.apache.camel.upgrade.customRecipes.internal.ChangeYamlComponentUriRecipe cannot be applied to given types;
> [ERROR]   required: no arguments
> [ERROR]   found:    java.lang.String,java.lang.String
> [ERROR]   reason: actual and formal argument lists differ in length
> [ERROR] -> [Help 1]