### PR TITLE
Add explicit permissions to CI and release workflows

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -35,6 +35,9 @@ on:
       - 'KEYS'
       - 'LICENSE.txt'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -23,6 +23,9 @@ on:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/receive-pr.yml
+++ b/.github/workflows/receive-pr.yml
@@ -10,6 +10,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary
- Add explicit workflow token permissions to `.github/workflows/ci-build.yaml` (`contents: read`), `.github/workflows/receive-pr.yml` (`contents: read`), and `.github/workflows/github-release.yml` (`contents: write`).
- Keep scopes minimal and aligned with each workflow behavior.

## Why
Declaring token permissions explicitly improves least-privilege posture and avoids relying on repository defaults. The release workflow needs write access for `gh release create`, while CI and PR-processing workflows only need read access.

_This PR description is AI-generated by OpenCode on behalf of Arpit Jain._