### PR TITLE
Fix Java version downgrade, YAML DSL scoping, remove Lombok, fix LST patterns

### DIFF
--- a/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/spring-boot-3-to-4.yaml
+++ b/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/spring-boot-3-to-4.yaml
@@ -19,22 +19,11 @@
 type: specs.openrewrite.org/v1beta/recipe
 name: org.apache.camel.upgrade.spring.UpgradeSpringBoot3To4
 displayName: Upgrade Spring Boot from 3.* to 4.*
-description: Upgrades Spring Boot dependencies from 3.* to 4.* based on https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-4.0-Migration-Guide
+description: Upgrades Spring Boot dependencies from 3.* to 4.* based on https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-4.0-Migration-Guide.
 recipeList:
   # Update Java version to 17 (minimum for Spring Boot 4)
   - org.apache.camel.upgrade.UpgradeToJava17
-  - org.openrewrite.maven.ChangePropertyValue:
-      key: java.version
-      newValue: "17"
-  - org.openrewrite.maven.ChangePropertyValue:
-      key: maven.compiler.source
-      newValue: "17"
-  - org.openrewrite.maven.ChangePropertyValue:
-      key: maven.compiler.target
-      newValue: "17"
-  - org.openrewrite.maven.ChangePropertyValue:
-      key: maven.compiler.release
-      newValue: "17"
+  - org.apache.camel.upgrade.JavaVersion17
   # Update Spring Boot version property
   - org.openrewrite.maven.ChangePropertyValue:
       key: spring-boot.version

--- a/camel-spring-boot-upgrade-recipes/src/test/java/org/apache/camel/upgrade/springboot/UpgradeSpringBoot3To4Test.java
+++ b/camel-spring-boot-upgrade-recipes/src/test/java/org/apache/camel/upgrade/springboot/UpgradeSpringBoot3To4Test.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.camel.upgrade.springboot;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.config.Environment;
+import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.RewriteTest;
+
+import static org.openrewrite.maven.Assertions.pomXml;
+
+class UpgradeSpringBoot3To4Test implements RewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.recipe(Environment.builder()
+                .scanYamlResources()
+                .build()
+                .activateRecipes("org.apache.camel.upgrade.spring.UpgradeSpringBoot3To4"));
+    }
+
+    @Test
+    void javaVersionNotDowngraded() {
+        rewriteRun(
+            //language=xml
+            pomXml(
+                """
+                    <project>
+                        <modelVersion>4.0.0</modelVersion>
+                        <groupId>com.example</groupId>
+                        <artifactId>test</artifactId>
+                        <version>1.0.0</version>
+                        <properties>
+                            <java.version>21</java.version>
+                            <maven.compiler.source>21</maven.compiler.source>
+                            <maven.compiler.target>21</maven.compiler.target>
+                            <maven.compiler.release>21</maven.compiler.release>
+                        </properties>
+                    </project>
+                    """
+            )
+        );
+    }
+
+    @Test
+    void javaVersionUpgradedFromOlder() {
+        rewriteRun(
+            //language=xml
+            pomXml(
+                """
+                    <project>
+                        <modelVersion>4.0.0</modelVersion>
+                        <groupId>com.example</groupId>
+                        <artifactId>test</artifactId>
+                        <version>1.0.0</version>
+                        <properties>
+                            <java.version>11</java.version>
+                        </properties>
+                    </project>
+                    """,
+                """
+                    <project>
+                        <modelVersion>4.0.0</modelVersion>
+                        <groupId>com.example</groupId>
+                        <artifactId>test</artifactId>
+                        <version>1.0.0</version>
+                        <properties>
+                            <java.version>17</java.version>
+                        </properties>
+                    </project>
+                    """
+            )
+        );
+    }
+}

--- a/camel-upgrade-recipes/pom.xml
+++ b/camel-upgrade-recipes/pom.xml
@@ -108,14 +108,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.projectlombok</groupId>
-            <artifactId>lombok</artifactId>
-            <version>${lombok.version}</version>
-            <scope>provided</scope>
-            <optional>true</optional>
-        </dependency>
-
-        <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-suite</artifactId>
             <version>1.13.4</version>
@@ -158,6 +150,8 @@
                         <include>**/*Test.java</include>
                         <include>**/*Suite.java</include>
                     </includes>
+                    <forkCount>2C</forkCount>
+                    <reuseForks>true</reuseForks>
                 </configuration>
             </plugin>
 

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/RecipesUtil.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/RecipesUtil.java
@@ -21,7 +21,9 @@ import org.openrewrite.*;
 import org.openrewrite.java.search.UsesType;
 import org.openrewrite.java.tree.*;
 import org.openrewrite.marker.Markers;
+import org.openrewrite.marker.SearchResult;
 import org.openrewrite.xml.tree.Xml;
+import org.openrewrite.yaml.YamlIsoVisitor;
 import org.openrewrite.yaml.tree.Yaml;
 
 import java.util.*;
@@ -42,6 +44,44 @@ public class RecipesUtil {
 
     public static TreeVisitor<?, ExecutionContext> newVisitor(String requiredImport, AbstractCamelJavaVisitor visitor) {
         return Preconditions.check(new UsesType<>(requiredImport, false), visitor);
+    }
+
+    // ---------------- Camel YAML DSL precondition
+    private static final Set<String> CAMEL_DSL_ROOT_KEYS = Set.of(
+            "route", "routes", "from", "rest", "beans",
+            "route-configuration", "routeConfiguration",
+            "route-template", "routeTemplate",
+            "templated-route", "templatedRoute",
+            "rest-configuration", "restConfiguration",
+            "error-handler", "errorHandler",
+            "on-exception", "onException",
+            "intercept", "intercept-from", "interceptFrom",
+            "intercept-send-to-endpoint", "interceptSendToEndpoint",
+            "dataFormats", "data-formats");
+
+    public static TreeVisitor<?, ExecutionContext> camelYamlDslPrecondition() {
+        return new YamlIsoVisitor<ExecutionContext>() {
+            @Override
+            public Yaml.Document visitDocument(Yaml.Document document, ExecutionContext ctx) {
+                if (hasCamelRootKey(document.getBlock())) {
+                    return SearchResult.found(document);
+                }
+                return document;
+            }
+        };
+    }
+
+    public static boolean hasCamelRootKey(Yaml.Block block) {
+        if (block instanceof Yaml.Mapping) {
+            return ((Yaml.Mapping) block).getEntries().stream()
+                    .anyMatch(entry -> CAMEL_DSL_ROOT_KEYS.contains(entry.getKey().getValue()));
+        }
+        if (block instanceof Yaml.Sequence) {
+            return ((Yaml.Sequence) block).getEntries().stream()
+                    .map(Yaml.Sequence.Entry::getBlock)
+                    .anyMatch(RecipesUtil::hasCamelRootKey);
+        }
+        return false;
     }
 
     //---------------- annotations helpers

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel40/java/CamelAPIsRecipe.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel40/java/CamelAPIsRecipe.java
@@ -16,8 +16,6 @@
  */
 package org.apache.camel.upgrade.camel40.java;
 
-import lombok.EqualsAndHashCode;
-import lombok.Value;
 import org.apache.camel.upgrade.AbstractCamelJavaVisitor;
 import org.apache.camel.upgrade.RecipesUtil;
 import org.jspecify.annotations.Nullable;
@@ -39,8 +37,6 @@ import java.util.regex.Pattern;
  * Recipe migrating changes between Camel 3.x to 4.x, for more details see the
  * <a href="https://camel.apache.org/manual/camel-4-migration-guide.html#_api_changes">documentation</a>.
  */
-@EqualsAndHashCode(callSuper = false)
-@Value
 public class CamelAPIsRecipe extends Recipe {
 
     private static final String MATCHER_CONTEXT_GET_ENDPOINT_MAP = "org.apache.camel.CamelContext getEndpointMap()";

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel40/java/CamelHttpRecipe.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel40/java/CamelHttpRecipe.java
@@ -16,8 +16,6 @@
  */
 package org.apache.camel.upgrade.camel40.java;
 
-import lombok.EqualsAndHashCode;
-import lombok.Value;
 import org.apache.camel.upgrade.AbstractCamelJavaVisitor;
 import org.apache.camel.upgrade.RecipesUtil;
 import org.jspecify.annotations.Nullable;
@@ -28,8 +26,6 @@ import org.openrewrite.java.ChangeType;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.tree.J;
 
-@EqualsAndHashCode(callSuper = false)
-@Value
 public class CamelHttpRecipe extends Recipe {
 
     private static final String SET_CREDENTIALS = "org.apache.http.impl.client.BasicCredentialsProvider setCredentials(..)";

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel40/yaml/CamelYamlRouteConfigurationSequenceRecipe.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel40/yaml/CamelYamlRouteConfigurationSequenceRecipe.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.upgrade.camel40.yaml;
 
-import lombok.EqualsAndHashCode;
-import lombok.Value;
 import org.apache.camel.upgrade.AbstractCamelYamlVisitor;
+import org.apache.camel.upgrade.RecipesUtil;
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.yaml.JsonPathMatcher;
@@ -37,8 +37,6 @@ import static org.openrewrite.Tree.randomId;
  * Camel API changes requires several changes in YAML route definition. Route-configuration children sequence is
  * replaced with mappingEntry (with special migration of "on-exception")
  */
-@EqualsAndHashCode(callSuper = false)
-@Value
 public class CamelYamlRouteConfigurationSequenceRecipe extends Recipe {
 
     @Override
@@ -54,7 +52,7 @@ public class CamelYamlRouteConfigurationSequenceRecipe extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
 
-        return new AbstractCamelYamlVisitor() {
+        return Preconditions.check(RecipesUtil.camelYamlDslPrecondition(), new AbstractCamelYamlVisitor() {
 
             private Yaml.Sequence sequenceToReplace;
             private boolean indentRegistered = false;
@@ -117,7 +115,7 @@ public class CamelYamlRouteConfigurationSequenceRecipe extends Recipe {
                 }
                 return e;
             }
-        };
+        });
     }
 
 }

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel40/yaml/CamelYamlStepsInFromRecipe.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel40/yaml/CamelYamlStepsInFromRecipe.java
@@ -16,21 +16,20 @@
  */
 package org.apache.camel.upgrade.camel40.yaml;
 
-import lombok.EqualsAndHashCode;
-import lombok.Value;
 import org.apache.camel.upgrade.AbstractCamelYamlVisitor;
 import org.apache.camel.upgrade.RecipesUtil;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.ListUtils;
 import org.openrewrite.yaml.JsonPathMatcher;
 import org.openrewrite.yaml.YamlIsoVisitor;
 import org.openrewrite.yaml.format.IndentsVisitor;
 import org.openrewrite.yaml.style.IndentsStyle;
 import org.openrewrite.yaml.tree.Yaml;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -58,8 +57,6 @@ import java.util.List;
  *       - log: "message"
  * </pre>
  */
-@EqualsAndHashCode(callSuper = false)
-@Value
 public class CamelYamlStepsInFromRecipe extends Recipe {
 
     private static final String[] PATHS_TO_PRE_CHECK = new String[] { "route.from" };
@@ -79,7 +76,7 @@ public class CamelYamlStepsInFromRecipe extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
 
-        return new AbstractCamelYamlVisitor() {
+        return Preconditions.check(RecipesUtil.camelYamlDslPrecondition(), new AbstractCamelYamlVisitor() {
             //both variables has to be set to null, to mark the migration done
             Yaml.Mapping from = null;
             Yaml.Mapping.Entry steps = null;
@@ -127,9 +124,7 @@ public class CamelYamlStepsInFromRecipe extends Recipe {
                         Yaml.Mapping m = super.visitMapping(mapping, ctx);
 
                         if (m == from) {
-                            List<Yaml.Mapping.Entry> entries = new ArrayList<>(m.getEntries());
-                            entries.add(steps.copyPaste().withPrefix("\n"));
-                            m = m.withEntries(entries);
+                            m = m.withEntries(ListUtils.concat(m.getEntries(), steps.copyPaste().withPrefix("\n")));
                         }
 
                         return m;
@@ -139,7 +134,7 @@ public class CamelYamlStepsInFromRecipe extends Recipe {
                 //TODO might probably change indent in original file, may this happen?
                 doAfterVisit(new IndentsVisitor(new IndentsStyle(2), null));
             }
-        };
+        });
     }
 
 }

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel41/CamelCoreRecipe.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel41/CamelCoreRecipe.java
@@ -16,8 +16,6 @@
  */
 package org.apache.camel.upgrade.camel41;
 
-import lombok.EqualsAndHashCode;
-import lombok.Value;
 import org.apache.camel.upgrade.AbstractCamelJavaVisitor;
 import org.apache.camel.upgrade.RecipesUtil;
 import org.openrewrite.ExecutionContext;
@@ -32,8 +30,6 @@ import java.util.regex.Pattern;
  * Recipe migrating changes between Camel 4.3 to 4.4, for more details see the
  * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_4.html#_camel_core" >documentation</a>.
  */
-@EqualsAndHashCode(callSuper = false)
-@Value
 public class CamelCoreRecipe extends Recipe {
 
     private static final String M_TO = "org.apache.camel.model.ProcessorDefinition to(..)";

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel41/XmlDslRecipe.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel41/XmlDslRecipe.java
@@ -21,11 +21,11 @@ import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.Tree;
 import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.ListUtils;
 import org.openrewrite.marker.Markers;
 import org.openrewrite.xml.XPathMatcher;
 import org.openrewrite.xml.tree.Xml;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -87,18 +87,20 @@ public class XmlDslRecipe extends Recipe {
                     //if values are not empty, migrate tag
                     if (typeAttr.isPresent() && !typeAttr.get().getValueAsString().isEmpty() && beanTypeAttr.isPresent() &&
                             !beanTypeAttr.get().getValueAsString().isEmpty()) {
-                        // gather attributes
-                        List<Xml.Attribute> attrs = new ArrayList<>(t.getAttributes());
-                        attrs.remove(typeAttr.get());
-                        attrs.remove(beanTypeAttr.get());
-
-                        //migrate values
                         Xml.Attribute.Value tmp = typeAttr.get().getValue();
-                        attrs.add(typeAttr.get().withValue(beanTypeAttr.get().getValue()));
-                        attrs.add(beanTypeAttr.get()
-                                .withKey(new Xml.Ident(Tree.randomId(), "", Markers.EMPTY, "scriptLanguage")).withValue(tmp));
+                        Xml.Attribute newType = typeAttr.get().withValue(beanTypeAttr.get().getValue());
+                        Xml.Attribute newScriptLang = beanTypeAttr.get()
+                                .withKey(new Xml.Ident(Tree.randomId(), "", Markers.EMPTY, "scriptLanguage")).withValue(tmp);
 
-                        t = t.withAttributes(attrs);
+                        t = t.withAttributes(ListUtils.map(t.getAttributes(), attr -> {
+                            if (attr == typeAttr.get()) {
+                                return newType;
+                            }
+                            if (attr == beanTypeAttr.get()) {
+                                return newScriptLang;
+                            }
+                            return attr;
+                        }));
                     }
 
                 }

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel41/YamlDslRecipe.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel41/YamlDslRecipe.java
@@ -16,11 +16,11 @@
  */
 package org.apache.camel.upgrade.camel41;
 
-import lombok.EqualsAndHashCode;
-import lombok.Value;
 import org.apache.camel.upgrade.AbstractCamelYamlVisitor;
+import org.apache.camel.upgrade.RecipesUtil;
 import org.openrewrite.Cursor;
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.yaml.JsonPathMatcher;
@@ -57,8 +57,6 @@ import java.util.Optional;
  *         # groovy script here
  * </pre>
  */
-@EqualsAndHashCode(callSuper = false)
-@Value
 public class YamlDslRecipe extends Recipe {
 
     private static final JsonPathMatcher MATCHER_WITHOUT_ROUTE = new JsonPathMatcher("$.beans");
@@ -76,7 +74,7 @@ public class YamlDslRecipe extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
 
-        return new AbstractCamelYamlVisitor() {
+        return Preconditions.check(RecipesUtil.camelYamlDslPrecondition(), new AbstractCamelYamlVisitor() {
 
             @Override
             protected void clearLocalCache() {
@@ -119,7 +117,7 @@ public class YamlDslRecipe extends Recipe {
 
                 return e;
             }
-        };
+        });
     }
 
 }

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel412/Java412Recipes.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel412/Java412Recipes.java
@@ -16,8 +16,6 @@
  */
 package org.apache.camel.upgrade.camel412;
 
-import lombok.EqualsAndHashCode;
-import lombok.RequiredArgsConstructor;
 import org.apache.camel.upgrade.AbstractCamelJavaVisitor;
 import org.apache.camel.upgrade.RecipesUtil;
 import org.openrewrite.ExecutionContext;
@@ -28,8 +26,6 @@ import org.openrewrite.java.tree.J;
 /**
  * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_12.html#_java_dsl">Java DSL</a>
  */
-@EqualsAndHashCode(callSuper = false)
-@RequiredArgsConstructor
 public class Java412Recipes extends Recipe {
 
     private static final String M_END_CHOICE = "org.apache.camel.model.ChoiceDefinition endChoice()";

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel413/YamlDsl413Recipe.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel413/YamlDsl413Recipe.java
@@ -16,19 +16,13 @@
  */
 package org.apache.camel.upgrade.camel413;
 
-import lombok.EqualsAndHashCode;
-import lombok.Value;
 import org.apache.camel.upgrade.AbstractCamelYamlVisitor;
 import org.apache.camel.upgrade.RecipesUtil;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
-import org.openrewrite.marker.SearchResult;
-import org.openrewrite.yaml.YamlIsoVisitor;
 import org.openrewrite.yaml.tree.Yaml;
-
-import java.util.Set;
 
 /**
  * <p>
@@ -36,22 +30,7 @@ import java.util.Set;
  * </p>
  * Kebab-case is changed to camelCase.
  */
-@EqualsAndHashCode(callSuper = false)
-@Value
 public class YamlDsl413Recipe extends Recipe {
-
-    // Root-level keys that identify a YAML document as Camel YAML DSL,
-    // so the rewrite does not touch unrelated YAML (Kubernetes, GitHub Actions, Helm, etc.).
-    private static final Set<String> CAMEL_DSL_ROOT_KEYS = Set.of(
-            "route", "routes", "from", "rest", "beans",
-            "route-configuration", "routeConfiguration",
-            "route-template", "routeTemplate",
-            "templated-route", "templatedRoute",
-            "rest-configuration", "restConfiguration",
-            "error-handler", "errorHandler",
-            "on-exception", "onException",
-            "intercept", "intercept-from", "interceptFrom",
-            "intercept-send-to-endpoint", "interceptSendToEndpoint");
 
     @Override
     public String getDisplayName() {
@@ -66,17 +45,7 @@ public class YamlDsl413Recipe extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
 
-        TreeVisitor<?, ExecutionContext> camelYamlDslCheck = new YamlIsoVisitor<ExecutionContext>() {
-            @Override
-            public Yaml.Document visitDocument(Yaml.Document document, ExecutionContext ctx) {
-                if (hasCamelRootKey(document.getBlock())) {
-                    return SearchResult.found(document);
-                }
-                return document;
-            }
-        };
-
-        return Preconditions.check(camelYamlDslCheck, new AbstractCamelYamlVisitor() {
+        return Preconditions.check(RecipesUtil.camelYamlDslPrecondition(), new AbstractCamelYamlVisitor() {
 
             @Override
             protected void clearLocalCache() {
@@ -106,19 +75,6 @@ public class YamlDsl413Recipe extends Recipe {
             }
 
         });
-    }
-
-    private static boolean hasCamelRootKey(Yaml.Block block) {
-        if (block instanceof Yaml.Mapping) {
-            return ((Yaml.Mapping) block).getEntries().stream()
-                    .anyMatch(entry -> CAMEL_DSL_ROOT_KEYS.contains(entry.getKey().getValue()));
-        }
-        if (block instanceof Yaml.Sequence) {
-            return ((Yaml.Sequence) block).getEntries().stream()
-                    .map(Yaml.Sequence.Entry::getBlock)
-                    .anyMatch(YamlDsl413Recipe::hasCamelRootKey);
-        }
-        return false;
     }
 
 }

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel416/Camel416MiloLambdaRecipe.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel416/Camel416MiloLambdaRecipe.java
@@ -1,7 +1,5 @@
 package org.apache.camel.upgrade.camel416;
 
-import lombok.EqualsAndHashCode;
-import lombok.RequiredArgsConstructor;
 import org.apache.camel.upgrade.AbstractCamelJavaVisitor;
 import org.apache.camel.upgrade.RecipesUtil;
 import org.openrewrite.ExecutionContext;
@@ -21,8 +19,6 @@ import java.util.List;
 /**
  * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_16.html#_subscription_monitoring_api_changes">Java Milo Subscription API changes</a>
  */
-@EqualsAndHashCode(callSuper = false)
-@RequiredArgsConstructor
 public class Camel416MiloLambdaRecipe extends Recipe {
 
     private static final MethodMatcher MATCHER =

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel417/YamlTransform417Recipe.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel417/YamlTransform417Recipe.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.upgrade.camel417;
 
-import lombok.EqualsAndHashCode;
-import lombok.Value;
 import org.apache.camel.upgrade.AbstractCamelYamlVisitor;
+import org.apache.camel.upgrade.RecipesUtil;
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.yaml.JsonPathMatcher;
@@ -30,8 +30,6 @@ import org.openrewrite.yaml.tree.Yaml;
  * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_17.html#_camel_core">camel-core for yaml</a>
  * </p>
  */
-@EqualsAndHashCode(callSuper = false)
-@Value
 public class YamlTransform417Recipe extends Recipe {
 
     @Override
@@ -49,7 +47,7 @@ public class YamlTransform417Recipe extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
 
-         return new AbstractCamelYamlVisitor() {
+         return Preconditions.check(RecipesUtil.camelYamlDslPrecondition(), new AbstractCamelYamlVisitor() {
 
             @Override
             protected void clearLocalCache() {
@@ -68,7 +66,7 @@ public class YamlTransform417Recipe extends Recipe {
                 return e;
             }
 
-        };
+        });
     }
 
 }

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel419/Pom419TestInfraRecipe.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel419/Pom419TestInfraRecipe.java
@@ -19,6 +19,7 @@ package org.apache.camel.upgrade.camel419;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.ListUtils;
 import org.openrewrite.xml.XPathMatcher;
 import org.openrewrite.xml.XmlVisitor;
 import org.openrewrite.xml.tree.Xml;
@@ -65,11 +66,9 @@ public class Pom419TestInfraRecipe extends Recipe {
                         // Check if it has <type>test-jar</type>
                         Optional<Xml.Tag> typeTag = t.getChild("type");
                         if (typeTag.isPresent() && "test-jar".equals(typeTag.get().getValue().orElse(""))) {
-                            // Remove the type tag
                             t = t.withContent(
-                                t.getContent().stream()
-                                    .filter(content -> content != typeTag.get())
-                                    .toList()
+                                ListUtils.flatMap(t.getContent(), content ->
+                                    content == typeTag.get() ? null : content)
                             );
                         }
                     }

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel419/XmlDsl419SagaRecipe.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel419/XmlDsl419SagaRecipe.java
@@ -20,10 +20,10 @@ import org.apache.camel.upgrade.AbstractCamelXmlVisitor;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.ListUtils;
 import org.openrewrite.xml.XPathMatcher;
 import org.openrewrite.xml.tree.Xml;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -57,66 +57,62 @@ public class XmlDsl419SagaRecipe extends Recipe {
                 Xml.Tag t = super.doVisitTag(tag, ctx);
 
                 if (SAGA_MATCHER.matches(getCursor())) {
-                    List<Xml.Tag> children = new ArrayList<>(t.getChildren());
-                    List<Xml.Attribute> attributes = new ArrayList<>(t.getAttributes());
-                    boolean modified = false;
-
-                    modified |= convertChildElementToAttribute(children, attributes, "compensation");
-                    modified |= convertChildElementToAttribute(children, attributes, "completion");
-
-                    if (modified) {
-                        t = t.withContent(children);
-                        t = t.withAttributes(attributes);
-                    }
+                    t = convertChildElementToAttribute(t, "compensation");
+                    t = convertChildElementToAttribute(t, "completion");
                 }
 
                 return t;
             }
 
-            private boolean convertChildElementToAttribute(List<Xml.Tag> children, List<Xml.Attribute> attributes, String elementName) {
-                Optional<Xml.Tag> childTag = children.stream()
+            private Xml.Tag convertChildElementToAttribute(Xml.Tag t, String elementName) {
+                Optional<Xml.Tag> childTag = t.getChildren().stream()
                         .filter(child -> elementName.equals(child.getName()))
                         .findFirst();
 
-                if (childTag.isPresent()) {
-                    Xml.Tag tag = childTag.get();
-                    String uri = null;
-
-                    // First, try to get the uri from the 'uri' attribute
-                    Optional<Xml.Attribute> uriAttr = tag.getAttributes().stream()
-                            .filter(attr -> "uri".equals(attr.getKeyAsString()))
-                            .findFirst();
-
-                    if (uriAttr.isPresent()) {
-                        uri = uriAttr.get().getValueAsString();
-                    } else if (tag.getValue().isPresent()) {
-                        // Fallback to text content if no uri attribute
-                        uri = tag.getValue().get().trim();
-                    }
-
-                    if (uri != null && !uri.isEmpty()) {
-                        children.removeIf(child -> elementName.equals(child.getName()));
-
-                        if (attributes.stream().noneMatch(a -> elementName.equals(a.getKeyAsString()))) {
-                            attributes.add(new Xml.Attribute(
-                                    org.openrewrite.Tree.randomId(),
-                                    " ",
-                                    org.openrewrite.marker.Markers.EMPTY,
-                                    new Xml.Ident(org.openrewrite.Tree.randomId(), "", org.openrewrite.marker.Markers.EMPTY, elementName),
-                                    "",
-                                    new Xml.Attribute.Value(
-                                            org.openrewrite.Tree.randomId(),
-                                            "",
-                                            org.openrewrite.marker.Markers.EMPTY,
-                                            Xml.Attribute.Value.Quote.Double,
-                                            uri
-                                    )
-                            ));
-                        }
-                        return true;
-                    }
+                if (childTag.isEmpty()) {
+                    return t;
                 }
-                return false;
+
+                Xml.Tag found = childTag.get();
+                String uri = null;
+
+                Optional<Xml.Attribute> uriAttr = found.getAttributes().stream()
+                        .filter(attr -> "uri".equals(attr.getKeyAsString()))
+                        .findFirst();
+
+                if (uriAttr.isPresent()) {
+                    uri = uriAttr.get().getValueAsString();
+                } else if (found.getValue().isPresent()) {
+                    uri = found.getValue().get().trim();
+                }
+
+                if (uri == null || uri.isEmpty()) {
+                    return t;
+                }
+
+                if (t.getAttributes().stream().anyMatch(a -> elementName.equals(a.getKeyAsString()))) {
+                    return t;
+                }
+
+                t = t.withContent(ListUtils.flatMap(t.getContent(), content ->
+                        content instanceof Xml.Tag && elementName.equals(((Xml.Tag) content).getName()) ? null : content));
+
+                t = t.withAttributes(ListUtils.concat(t.getAttributes(), new Xml.Attribute(
+                        org.openrewrite.Tree.randomId(),
+                        " ",
+                        org.openrewrite.marker.Markers.EMPTY,
+                        new Xml.Ident(org.openrewrite.Tree.randomId(), "", org.openrewrite.marker.Markers.EMPTY, elementName),
+                        "",
+                        new Xml.Attribute.Value(
+                                org.openrewrite.Tree.randomId(),
+                                "",
+                                org.openrewrite.marker.Markers.EMPTY,
+                                Xml.Attribute.Value.Quote.Double,
+                                uri
+                        )
+                )));
+
+                return t;
             }
         };
     }

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel419/YamlDsl419RoutePolicyRecipe.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel419/YamlDsl419RoutePolicyRecipe.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.upgrade.camel419;
 
-import lombok.EqualsAndHashCode;
-import lombok.Value;
 import org.apache.camel.upgrade.AbstractCamelYamlVisitor;
+import org.apache.camel.upgrade.RecipesUtil;
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.yaml.JsonPathMatcher;
@@ -31,8 +31,6 @@ import org.openrewrite.yaml.tree.Yaml;
  * </p>
  * In the YAML DSL we have renamed routePolicy to routePolicyRef.
  */
-@EqualsAndHashCode(callSuper = false)
-@Value
 public class YamlDsl419RoutePolicyRecipe extends Recipe {
 
     private static final JsonPathMatcher ROUTE_POLICY_MATCHER = new JsonPathMatcher("$..route.routePolicy");
@@ -50,7 +48,7 @@ public class YamlDsl419RoutePolicyRecipe extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
 
-        return new AbstractCamelYamlVisitor() {
+        return Preconditions.check(RecipesUtil.camelYamlDslPrecondition(), new AbstractCamelYamlVisitor() {
 
             @Override
             protected void clearLocalCache() {
@@ -72,6 +70,6 @@ public class YamlDsl419RoutePolicyRecipe extends Recipe {
 
                 return e;
             }
-        };
+        });
     }
 }

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel419/YamlDsl419SagaRecipe.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel419/YamlDsl419SagaRecipe.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.upgrade.camel419;
 
-import lombok.EqualsAndHashCode;
-import lombok.Value;
 import org.apache.camel.upgrade.AbstractCamelYamlVisitor;
+import org.apache.camel.upgrade.RecipesUtil;
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.yaml.JsonPathMatcher;
@@ -32,8 +32,6 @@ import org.openrewrite.yaml.tree.Yaml;
  * Changed model for configuring completion and compensation URIs in YAML DSL.
  * Flattens nested uri fields to direct attribute values.
  */
-@EqualsAndHashCode(callSuper = false)
-@Value
 public class YamlDsl419SagaRecipe extends Recipe {
 
     private static final JsonPathMatcher COMPENSATION_MATCHER = new JsonPathMatcher("$..saga.compensation");
@@ -52,7 +50,7 @@ public class YamlDsl419SagaRecipe extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
 
-        return new AbstractCamelYamlVisitor() {
+        return Preconditions.check(RecipesUtil.camelYamlDslPrecondition(), new AbstractCamelYamlVisitor() {
 
             @Override
             protected void clearLocalCache() {
@@ -82,6 +80,6 @@ public class YamlDsl419SagaRecipe extends Recipe {
 
                 return e;
             }
-        };
+        });
     }
 }

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel42/CamelSagaRecipe.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel42/CamelSagaRecipe.java
@@ -16,8 +16,6 @@
  */
 package org.apache.camel.upgrade.camel42;
 
-import lombok.EqualsAndHashCode;
-import lombok.Value;
 import org.apache.camel.upgrade.AbstractCamelJavaVisitor;
 import org.apache.camel.upgrade.RecipesUtil;
 import org.openrewrite.ExecutionContext;
@@ -32,8 +30,6 @@ import java.util.Collections;
  * Recipe migrating changes between Camel 4.3 to 4.4, for more details see the
  * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_4.html#_camel_core" >documentation</a>.
  */
-@EqualsAndHashCode(callSuper = false)
-@Value
 public class CamelSagaRecipe extends Recipe {
 
     private static final String M_NEW_SAGA = "org.apache.camel.saga.InMemorySagaService newSaga()";

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel43/CamelThrottleEIPRecipe.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel43/CamelThrottleEIPRecipe.java
@@ -16,8 +16,6 @@
  */
 package org.apache.camel.upgrade.camel43;
 
-import lombok.EqualsAndHashCode;
-import lombok.Value;
 import org.apache.camel.upgrade.AbstractCamelJavaVisitor;
 import org.apache.camel.upgrade.RecipesUtil;
 import org.openrewrite.ExecutionContext;
@@ -31,8 +29,6 @@ import java.util.Collections;
  * Recipe migrating changes between Camel 4.3 to 4.4, for more details see the
  * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_4.html#_camel_core" >documentation</a>.
  */
-@EqualsAndHashCode(callSuper = false)
-@Value
 public class CamelThrottleEIPRecipe extends Recipe {
 
     private static final String M_THROTTLE_PRIMITIVE = "org.apache.camel.model.ProcessorDefinition throttle(long)";

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel44/CamelCoreRecipe.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel44/CamelCoreRecipe.java
@@ -16,8 +16,6 @@
  */
 package org.apache.camel.upgrade.camel44;
 
-import lombok.EqualsAndHashCode;
-import lombok.Value;
 import org.apache.camel.upgrade.AbstractCamelJavaVisitor;
 import org.apache.camel.upgrade.RecipesUtil;
 import org.openrewrite.ExecutionContext;
@@ -35,8 +33,6 @@ import java.util.List;
  * Recipe migrating changes between Camel 4.3 to 4.4, for more details see the
  * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_4.html#_camel_core" >documentation</a>.
  */
-@EqualsAndHashCode(callSuper = false)
-@Value
 public class CamelCoreRecipe extends Recipe {
 
     private static final String M_EXCHANGE_GET_CREATED = "org.apache.camel.Exchange getCreated()";

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel46/YamlDsl46Recipe.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel46/YamlDsl46Recipe.java
@@ -16,12 +16,11 @@
  */
 package org.apache.camel.upgrade.camel46;
 
-import lombok.EqualsAndHashCode;
-import lombok.Value;
 import org.apache.camel.upgrade.AbstractCamelYamlVisitor;
 import org.apache.camel.upgrade.RecipesUtil;
 import org.jspecify.annotations.Nullable;
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.yaml.tree.Yaml;
@@ -55,8 +54,6 @@ import java.util.stream.Collectors;
  *          payload: "test-payload"
  * </pre>
  */
-@EqualsAndHashCode(callSuper = false)
-@Value
 public class YamlDsl46Recipe extends Recipe {
 
     @Override
@@ -72,7 +69,7 @@ public class YamlDsl46Recipe extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
 
-        return new AbstractCamelYamlVisitor() {
+        return Preconditions.check(RecipesUtil.camelYamlDslPrecondition(), new AbstractCamelYamlVisitor() {
 
             @Override
             protected void clearLocalCache() {
@@ -122,7 +119,7 @@ public class YamlDsl46Recipe extends Recipe {
                 return e;
             }
 
-        };
+        });
     }
 
 }

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel47/Java47Recipes.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel47/Java47Recipes.java
@@ -16,8 +16,6 @@
  */
 package org.apache.camel.upgrade.camel47;
 
-import lombok.EqualsAndHashCode;
-import lombok.RequiredArgsConstructor;
 import org.apache.camel.upgrade.AbstractCamelJavaVisitor;
 import org.apache.camel.upgrade.RecipesUtil;
 import org.openrewrite.ExecutionContext;
@@ -34,8 +32,6 @@ import java.util.Optional;
 /**
  * Replaces prefix with the new one and changes the suffix tp start with lower case
  */
-@EqualsAndHashCode(callSuper = false)
-@RequiredArgsConstructor
 public class Java47Recipes extends Recipe {
 
     /**

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel47/YamlDsl47Recipe.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/camel47/YamlDsl47Recipe.java
@@ -16,10 +16,10 @@
  */
 package org.apache.camel.upgrade.camel47;
 
-import lombok.EqualsAndHashCode;
-import lombok.Value;
 import org.apache.camel.upgrade.AbstractCamelYamlVisitor;
+import org.apache.camel.upgrade.RecipesUtil;
 import org.openrewrite.ExecutionContext;
+import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.yaml.JsonPathMatcher;
@@ -33,8 +33,6 @@ import java.util.Map;
  * </p>
  * The Load Balancer EIP has aligned naming and the following balancers has been renamed in XML and YAML DSL:
  */
-@EqualsAndHashCode(callSuper = false)
-@Value
 public class YamlDsl47Recipe extends Recipe {
 
 
@@ -60,7 +58,7 @@ public class YamlDsl47Recipe extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
 
-        return new AbstractCamelYamlVisitor() {
+        return Preconditions.check(RecipesUtil.camelYamlDslPrecondition(), new AbstractCamelYamlVisitor() {
 
             @Override
             protected void clearLocalCache() {
@@ -80,7 +78,7 @@ public class YamlDsl47Recipe extends Recipe {
                         .orElse(e);
             }
 
-        };
+        });
     }
 
 }

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/customRecipes/ChangeComponentUriRecipe.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/customRecipes/ChangeComponentUriRecipe.java
@@ -16,9 +16,6 @@
  */
 package org.apache.camel.upgrade.customRecipes;
 
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.RequiredArgsConstructor;
 import org.apache.camel.upgrade.customRecipes.internal.ChangeJavaComponentUriRecipe;
 import org.apache.camel.upgrade.customRecipes.internal.ChangeXmlComponentUriRecipe;
 import org.apache.camel.upgrade.customRecipes.internal.ChangeYamlComponentUriRecipe;
@@ -45,9 +42,6 @@ import java.util.List;
  * <p>
  * This will transform Pulsar URIs in Java code, XML DSL, and YAML DSL all at once.
  */
-@EqualsAndHashCode(callSuper = false)
-@RequiredArgsConstructor
-@AllArgsConstructor
 public class ChangeComponentUriRecipe extends Recipe {
 
     @Option(
@@ -63,6 +57,22 @@ public class ChangeComponentUriRecipe extends Recipe {
         example = "pulsar:${2}://${3}/${5}/${6}"
     )
     public String replacement;
+
+    public ChangeComponentUriRecipe() {
+    }
+
+    public ChangeComponentUriRecipe(String uriPattern, String replacement) {
+        this.uriPattern = uriPattern;
+        this.replacement = replacement;
+    }
+
+    public void setUriPattern(String uriPattern) {
+        this.uriPattern = uriPattern;
+    }
+
+    public void setReplacement(String replacement) {
+        this.replacement = replacement;
+    }
 
     @Override
     public String getDisplayName() {

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/customRecipes/ChangePropertyKeyWithCaseChange.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/customRecipes/ChangePropertyKeyWithCaseChange.java
@@ -16,10 +16,6 @@
  */
 package org.apache.camel.upgrade.customRecipes;
 
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Option;
 import org.openrewrite.Recipe;
@@ -32,10 +28,6 @@ import java.util.List;
 /**
  * Replaces prefix with the new one and changes the suffix tp start with lower case
  */
-@EqualsAndHashCode(callSuper = false)
-@RequiredArgsConstructor
-@AllArgsConstructor
-@Setter
 public class ChangePropertyKeyWithCaseChange extends Recipe {
 
     @Option(example = "TODO Provide a usage example for the docs", displayName = "Old property key",
@@ -50,6 +42,27 @@ public class ChangePropertyKeyWithCaseChange extends Recipe {
             description = "Regexp for exclusions",
             example = "camel.springboot.main-run-controller")
     List<String> exclusions = new ArrayList<>();
+
+    public ChangePropertyKeyWithCaseChange() {
+    }
+
+    public ChangePropertyKeyWithCaseChange(String oldPropertyKey, String newPrefix, List<String> exclusions) {
+        this.oldPropertyKey = oldPropertyKey;
+        this.newPrefix = newPrefix;
+        this.exclusions = exclusions;
+    }
+
+    public void setOldPropertyKey(String oldPropertyKey) {
+        this.oldPropertyKey = oldPropertyKey;
+    }
+
+    public void setNewPrefix(String newPrefix) {
+        this.newPrefix = newPrefix;
+    }
+
+    public void setExclusions(List<String> exclusions) {
+        this.exclusions = exclusions;
+    }
 
     @Override
     public String getDisplayName() {

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/customRecipes/LiteralRegexpConverterRecipe.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/customRecipes/LiteralRegexpConverterRecipe.java
@@ -16,9 +16,6 @@
  */
 package org.apache.camel.upgrade.customRecipes;
 
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.RequiredArgsConstructor;
 import org.apache.camel.upgrade.AbstractCamelJavaVisitor;
 import org.apache.camel.upgrade.RecipesUtil;
 import org.openrewrite.ExecutionContext;
@@ -33,9 +30,6 @@ import java.util.regex.Matcher;
 /**
  * Replaces literal matching pattern and replacing it with a replacement (regexp groups are supported)
  */
-@EqualsAndHashCode(callSuper = false)
-@RequiredArgsConstructor
-@AllArgsConstructor
 public class LiteralRegexpConverterRecipe extends Recipe {
 
     @Option(example = "TODO Provide a usage example for the docs", displayName = "Literal regexp name",
@@ -45,6 +39,22 @@ public class LiteralRegexpConverterRecipe extends Recipe {
     @Option(example = "TODO Provide a usage example for the docs", displayName = "Replacement to use",
             description = "Replacement to use.")
     public String replacement;
+
+    public LiteralRegexpConverterRecipe() {
+    }
+
+    public LiteralRegexpConverterRecipe(String regexp, String replacement) {
+        this.regexp = regexp;
+        this.replacement = replacement;
+    }
+
+    public void setRegexp(String regexp) {
+        this.regexp = regexp;
+    }
+
+    public void setReplacement(String replacement) {
+        this.replacement = replacement;
+    }
 
     @Override
     public String getDisplayName() {

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/customRecipes/MoveGetterToExtendedCamelContext.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/customRecipes/MoveGetterToExtendedCamelContext.java
@@ -16,9 +16,6 @@
  */
 package org.apache.camel.upgrade.customRecipes;
 
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.RequiredArgsConstructor;
 import org.apache.camel.upgrade.AbstractCamelJavaVisitor;
 import org.apache.camel.upgrade.RecipesUtil;
 import org.openrewrite.ExecutionContext;
@@ -33,9 +30,6 @@ import java.util.regex.Pattern;
 /**
  * Replaces prefix with the new one and changes the suffix tp start with lower case
  */
-@EqualsAndHashCode(callSuper = false)
-@RequiredArgsConstructor
-@AllArgsConstructor
 public class MoveGetterToExtendedCamelContext extends Recipe {
 
     private static final String MATCHER_GET_NAME_RESOLVER = "org.apache.camel.ExtendedCamelContext getComponentNameResolver()";
@@ -48,6 +42,17 @@ public class MoveGetterToExtendedCamelContext extends Recipe {
     @Option(example = "TODO Provide a usage example for the docs", displayName = "Method name",
             description = "Name of the method on external camel context.")
     public String oldMethodName;
+
+    public MoveGetterToExtendedCamelContext() {
+    }
+
+    public MoveGetterToExtendedCamelContext(String oldMethodName) {
+        this.oldMethodName = oldMethodName;
+    }
+
+    public void setOldMethodName(String oldMethodName) {
+        this.oldMethodName = oldMethodName;
+    }
 
     @Override
     public String getDisplayName() {

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/customRecipes/MoveGetterToPluginHelper.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/customRecipes/MoveGetterToPluginHelper.java
@@ -16,9 +16,6 @@
  */
 package org.apache.camel.upgrade.customRecipes;
 
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.RequiredArgsConstructor;
 import org.apache.camel.upgrade.AbstractCamelJavaVisitor;
 import org.apache.camel.upgrade.RecipesUtil;
 import org.openrewrite.ExecutionContext;
@@ -34,9 +31,6 @@ import java.util.regex.Pattern;
 /**
  * Replaces prefix with the new one and changes the suffix tp start with lower case
  */
-@EqualsAndHashCode(callSuper = false)
-@RequiredArgsConstructor
-@AllArgsConstructor
 public class MoveGetterToPluginHelper extends Recipe {
 
     private static final String MATCHER_GET_NAME_RESOLVER = "org.apache.camel.ExtendedCamelContext getComponentNameResolver()";
@@ -49,6 +43,17 @@ public class MoveGetterToPluginHelper extends Recipe {
     @Option(example = "TODO Provide a usage example for the docs", displayName = "Method name",
             description = "Name of the method on external camel context.")
     public String oldMethodName;
+
+    public MoveGetterToPluginHelper() {
+    }
+
+    public MoveGetterToPluginHelper(String oldMethodName) {
+        this.oldMethodName = oldMethodName;
+    }
+
+    public void setOldMethodName(String oldMethodName) {
+        this.oldMethodName = oldMethodName;
+    }
 
     @Override
     public String getDisplayName() {

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/customRecipes/PropertiesAndYamlKeyUpdate.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/customRecipes/PropertiesAndYamlKeyUpdate.java
@@ -1,19 +1,11 @@
 package org.apache.camel.upgrade.customRecipes;
 
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
 import org.openrewrite.Option;
 import org.openrewrite.Recipe;
 import org.openrewrite.properties.ChangePropertyKey;
 
 import java.util.List;
 
-@EqualsAndHashCode(callSuper = false)
-@RequiredArgsConstructor
-@AllArgsConstructor
-@Setter
 public class PropertiesAndYamlKeyUpdate extends Recipe {
 
     @Option(example = "TODO Provide a usage example for the docs", displayName = "Old configuration key",
@@ -23,6 +15,22 @@ public class PropertiesAndYamlKeyUpdate extends Recipe {
     @Option(example = "TODO Provide a usage example for the docs", displayName = "New configuration key",
             description = "The configuration to be replaced with.")
     String newPropertyKey;
+
+    public PropertiesAndYamlKeyUpdate() {
+    }
+
+    public PropertiesAndYamlKeyUpdate(String oldPropertyKey, String newPropertyKey) {
+        this.oldPropertyKey = oldPropertyKey;
+        this.newPropertyKey = newPropertyKey;
+    }
+
+    public void setOldPropertyKey(String oldPropertyKey) {
+        this.oldPropertyKey = oldPropertyKey;
+    }
+
+    public void setNewPropertyKey(String newPropertyKey) {
+        this.newPropertyKey = newPropertyKey;
+    }
 
     @Override
     public String getDisplayName() {

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/customRecipes/ReplacePropertyInComponentXml.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/customRecipes/ReplacePropertyInComponentXml.java
@@ -16,27 +16,18 @@
  */
 package org.apache.camel.upgrade.customRecipes;
 
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
 import org.apache.camel.upgrade.AbstractCamelXmlVisitor;
 import org.apache.camel.upgrade.RecipesUtil;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Option;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.ListUtils;
 import org.openrewrite.xml.XPathMatcher;
 import org.openrewrite.xml.tree.Xml;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 
-@EqualsAndHashCode(callSuper = false)
-@RequiredArgsConstructor
-@AllArgsConstructor
-@Setter
 public class ReplacePropertyInComponentXml extends Recipe {
 
     private static final XPathMatcher FROM_MATCHER = new XPathMatcher("//route/from");
@@ -59,6 +50,32 @@ public class ReplacePropertyInComponentXml extends Recipe {
             description = "This value is appended before the current value of the modified method.",
             required = false)
     String valuePrefix;
+
+    public ReplacePropertyInComponentXml() {
+    }
+
+    public ReplacePropertyInComponentXml(String component, String oldPropertyKey, String newPropertyKey, String valuePrefix) {
+        this.component = component;
+        this.oldPropertyKey = oldPropertyKey;
+        this.newPropertyKey = newPropertyKey;
+        this.valuePrefix = valuePrefix;
+    }
+
+    public void setComponent(String component) {
+        this.component = component;
+    }
+
+    public void setOldPropertyKey(String oldPropertyKey) {
+        this.oldPropertyKey = oldPropertyKey;
+    }
+
+    public void setNewPropertyKey(String newPropertyKey) {
+        this.newPropertyKey = newPropertyKey;
+    }
+
+    public void setValuePrefix(String valuePrefix) {
+        this.valuePrefix = valuePrefix;
+    }
 
     @Override
     public String getDisplayName() {
@@ -91,22 +108,16 @@ public class ReplacePropertyInComponentXml extends Recipe {
     }
 
     private Xml.Tag replacePropertyIfPossible(final Xml.Tag tag) {
-
-        List<Xml.Attribute> attributes = new ArrayList<>(tag.getAttributes());
-
-        Optional<Xml.Attribute> uri = attributes.stream().filter(a -> "uri".equals(a.getKey().getName())).findAny();
-        if(uri.isPresent() && (component.equals(uri.get().getValue().getValue()) || uri.get().getValue().getValue().startsWith(component + ":"))) {
-            String u = uri.get().getValue().getValue();
-            //replace property and apply optionalPrefix
-            u = RecipesUtil.replacePropertyInUrl(u, component, oldPropertyKey, newPropertyKey, valuePrefix);
-            if(u != null) {
-                attributes.remove(uri.get());
-                attributes.add(uri.get().withValue(uri.get().getValue().withValue(u)));
-                return tag.withAttributes(attributes);
+        Optional<Xml.Attribute> uri = tag.getAttributes().stream().filter(a -> "uri".equals(a.getKey().getName())).findAny();
+        if (uri.isPresent() && (component.equals(uri.get().getValue().getValue()) || uri.get().getValue().getValue().startsWith(component + ":"))) {
+            String u = RecipesUtil.replacePropertyInUrl(uri.get().getValue().getValue(), component, oldPropertyKey, newPropertyKey, valuePrefix);
+            if (u != null) {
+                Xml.Attribute matched = uri.get();
+                String newUri = u;
+                return tag.withAttributes(ListUtils.map(tag.getAttributes(), attr ->
+                        attr == matched ? attr.withValue(attr.getValue().withValue(newUri)) : attr));
             }
         }
         return tag;
-
-
     }
 }

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/customRecipes/ReplacePropertyInComponentYaml.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/customRecipes/ReplacePropertyInComponentYaml.java
@@ -16,14 +16,11 @@
  */
 package org.apache.camel.upgrade.customRecipes;
 
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
 import org.apache.camel.upgrade.AbstractCamelYamlVisitor;
 import org.apache.camel.upgrade.RecipesUtil;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Option;
+import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.yaml.search.FindKey;
@@ -31,10 +28,6 @@ import org.openrewrite.yaml.tree.Yaml;
 
 import java.util.Optional;
 
-@EqualsAndHashCode(callSuper = false)
-@RequiredArgsConstructor
-@AllArgsConstructor
-@Setter
 public class ReplacePropertyInComponentYaml extends Recipe {
 
     @Option(example = "TODO Provide a usage example for the docs", displayName = "Component",
@@ -54,6 +47,32 @@ public class ReplacePropertyInComponentYaml extends Recipe {
             required = false)
     String valuePrefix;
 
+    public ReplacePropertyInComponentYaml() {
+    }
+
+    public ReplacePropertyInComponentYaml(String component, String oldPropertyKey, String newPropertyKey, String valuePrefix) {
+        this.component = component;
+        this.oldPropertyKey = oldPropertyKey;
+        this.newPropertyKey = newPropertyKey;
+        this.valuePrefix = valuePrefix;
+    }
+
+    public void setComponent(String component) {
+        this.component = component;
+    }
+
+    public void setOldPropertyKey(String oldPropertyKey) {
+        this.oldPropertyKey = oldPropertyKey;
+    }
+
+    public void setNewPropertyKey(String newPropertyKey) {
+        this.newPropertyKey = newPropertyKey;
+    }
+
+    public void setValuePrefix(String valuePrefix) {
+        this.valuePrefix = valuePrefix;
+    }
+
     @Override
     public String getDisplayName() {
         return "Renames property of the component";
@@ -67,7 +86,7 @@ public class ReplacePropertyInComponentYaml extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
 
-        return new AbstractCamelYamlVisitor() {
+        return Preconditions.check(RecipesUtil.camelYamlDslPrecondition(), new AbstractCamelYamlVisitor() {
 
             @Override
             protected void clearLocalCache() {
@@ -108,7 +127,7 @@ public class ReplacePropertyInComponentYaml extends Recipe {
                 return e;
             }
 
-        };
+        });
     }
 
 }

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/customRecipes/ReplacePropertyInDataFormatXml.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/customRecipes/ReplacePropertyInDataFormatXml.java
@@ -16,26 +16,15 @@
  */
 package org.apache.camel.upgrade.customRecipes;
 
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
 import org.apache.camel.upgrade.AbstractCamelXmlVisitor;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Option;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.ListUtils;
 import org.openrewrite.xml.XPathMatcher;
 import org.openrewrite.xml.tree.Xml;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-
-@EqualsAndHashCode(callSuper = false)
-@RequiredArgsConstructor
-@AllArgsConstructor
-@Setter
 public class ReplacePropertyInDataFormatXml extends Recipe {
 
 
@@ -50,6 +39,27 @@ public class ReplacePropertyInDataFormatXml extends Recipe {
     @Option(example = "TODO Provide a usage example for the docs", displayName = "New prefix before any group",
             description = "The prefix to be replaced with.")
     String newPropertyKey;
+
+    public ReplacePropertyInDataFormatXml() {
+    }
+
+    public ReplacePropertyInDataFormatXml(String component, String oldPropertyKey, String newPropertyKey) {
+        this.component = component;
+        this.oldPropertyKey = oldPropertyKey;
+        this.newPropertyKey = newPropertyKey;
+    }
+
+    public void setComponent(String component) {
+        this.component = component;
+    }
+
+    public void setOldPropertyKey(String oldPropertyKey) {
+        this.oldPropertyKey = oldPropertyKey;
+    }
+
+    public void setNewPropertyKey(String newPropertyKey) {
+        this.newPropertyKey = newPropertyKey;
+    }
 
     @Override
     public String getDisplayName() {
@@ -78,15 +88,9 @@ public class ReplacePropertyInDataFormatXml extends Recipe {
     }
 
     private Xml.Tag replacePropertyIfPossible(final Xml.Tag tag) {
-
-        List<Xml.Attribute> attributes = new ArrayList<>(tag.getAttributes());
-
-        Optional<Xml.Attribute> property = attributes.stream().filter(a -> oldPropertyKey.equals(a.getKey().getName())).findAny();
-        if(property.isPresent()) {
-            attributes.remove(property.get());
-            attributes.add(property.get().withKey(property.get().getKey().withName(newPropertyKey)));
-            return tag.withAttributes(attributes);
-        }
-        return tag;
+        return tag.withAttributes(ListUtils.map(tag.getAttributes(), attr ->
+                oldPropertyKey.equals(attr.getKey().getName())
+                        ? attr.withKey(attr.getKey().withName(newPropertyKey))
+                        : attr));
     }
 }

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/customRecipes/ReplacePropertyInDataFormatYaml.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/customRecipes/ReplacePropertyInDataFormatYaml.java
@@ -16,22 +16,15 @@
  */
 package org.apache.camel.upgrade.customRecipes;
 
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
 import org.apache.camel.upgrade.AbstractCamelYamlVisitor;
 import org.apache.camel.upgrade.RecipesUtil;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Option;
+import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.yaml.tree.Yaml;
 
-@EqualsAndHashCode(callSuper = false)
-@RequiredArgsConstructor
-@AllArgsConstructor
-@Setter
 public class ReplacePropertyInDataFormatYaml extends Recipe {
 
     @Option(example = "TODO Provide a usage example for the docs", displayName = "Component",
@@ -45,6 +38,27 @@ public class ReplacePropertyInDataFormatYaml extends Recipe {
     @Option(example = "TODO Provide a usage example for the docs", displayName = "New prefix before any group",
             description = "The prefix to be replaced with.")
     String newPropertyKey;
+
+    public ReplacePropertyInDataFormatYaml() {
+    }
+
+    public ReplacePropertyInDataFormatYaml(String component, String oldPropertyKey, String newPropertyKey) {
+        this.component = component;
+        this.oldPropertyKey = oldPropertyKey;
+        this.newPropertyKey = newPropertyKey;
+    }
+
+    public void setComponent(String component) {
+        this.component = component;
+    }
+
+    public void setOldPropertyKey(String oldPropertyKey) {
+        this.oldPropertyKey = oldPropertyKey;
+    }
+
+    public void setNewPropertyKey(String newPropertyKey) {
+        this.newPropertyKey = newPropertyKey;
+    }
 
 
     @Override
@@ -60,7 +74,7 @@ public class ReplacePropertyInDataFormatYaml extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
 
-        return new AbstractCamelYamlVisitor() {
+        return Preconditions.check(RecipesUtil.camelYamlDslPrecondition(), new AbstractCamelYamlVisitor() {
 
             @Override
             protected void clearLocalCache() {
@@ -87,7 +101,7 @@ public class ReplacePropertyInDataFormatYaml extends Recipe {
                 return e;
             }
 
-        };
+        });
     }
 
 }

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/customRecipes/internal/ChangeJavaComponentUriRecipe.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/customRecipes/internal/ChangeJavaComponentUriRecipe.java
@@ -16,9 +16,6 @@
  */
 package org.apache.camel.upgrade.customRecipes.internal;
 
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.RequiredArgsConstructor;
 import org.apache.camel.upgrade.AbstractCamelJavaVisitor;
 import org.apache.camel.upgrade.RecipesUtil;
 import org.openrewrite.ExecutionContext;
@@ -33,9 +30,6 @@ import java.util.regex.Pattern;
 /**
  * Transform component URIs in Java code using regexp with capturing groups.
  */
-@EqualsAndHashCode(callSuper = false)
-@RequiredArgsConstructor
-@AllArgsConstructor
 public class ChangeJavaComponentUriRecipe extends Recipe {
 
     @Option(
@@ -51,6 +45,22 @@ public class ChangeJavaComponentUriRecipe extends Recipe {
         example = "pulsar:${2}://${3}/${5}/${6}"
     )
     public String replacement;
+
+    public ChangeJavaComponentUriRecipe() {
+    }
+
+    public ChangeJavaComponentUriRecipe(String uriPattern, String replacement) {
+        this.uriPattern = uriPattern;
+        this.replacement = replacement;
+    }
+
+    public void setUriPattern(String uriPattern) {
+        this.uriPattern = uriPattern;
+    }
+
+    public void setReplacement(String replacement) {
+        this.replacement = replacement;
+    }
 
     @Override
     public String getDisplayName() {

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/customRecipes/internal/ChangeXmlComponentUriRecipe.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/customRecipes/internal/ChangeXmlComponentUriRecipe.java
@@ -16,29 +16,21 @@
  */
 package org.apache.camel.upgrade.customRecipes.internal;
 
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.RequiredArgsConstructor;
 import org.apache.camel.upgrade.AbstractCamelXmlVisitor;
 import org.apache.camel.upgrade.RecipesUtil;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Option;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
+import org.openrewrite.internal.ListUtils;
 import org.openrewrite.xml.XPathMatcher;
 import org.openrewrite.xml.tree.Xml;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
 import java.util.regex.Pattern;
 
 /**
  * Transform component URIs in XML DSL using regexp with capturing groups.
  */
-@EqualsAndHashCode(callSuper = false)
-@RequiredArgsConstructor
-@AllArgsConstructor
 public class ChangeXmlComponentUriRecipe extends Recipe {
 
     private static final XPathMatcher FROM_MATCHER = new XPathMatcher("//route/from");
@@ -57,6 +49,22 @@ public class ChangeXmlComponentUriRecipe extends Recipe {
         example = "pulsar:${2}://${3}/${5}/${6}"
     )
     public String replacement;
+
+    public ChangeXmlComponentUriRecipe() {
+    }
+
+    public ChangeXmlComponentUriRecipe(String uriPattern, String replacement) {
+        this.uriPattern = uriPattern;
+        this.replacement = replacement;
+    }
+
+    public void setUriPattern(String uriPattern) {
+        this.uriPattern = uriPattern;
+    }
+
+    public void setReplacement(String replacement) {
+        this.replacement = replacement;
+    }
 
     @Override
     public String getDisplayName() {
@@ -87,22 +95,13 @@ public class ChangeXmlComponentUriRecipe extends Recipe {
     }
 
     private static Xml.Tag transformXmlUri(Xml.Tag tag, Pattern pattern, String replacement) {
-        List<Xml.Attribute> attributes = new ArrayList<>(tag.getAttributes());
-        Optional<Xml.Attribute> uriAttr = attributes.stream()
-                .filter(a -> "uri".equals(a.getKey().getName()))
-                .findFirst();
-
-        if (uriAttr.isPresent()) {
-            String originalUri = uriAttr.get().getValue().getValue();
-            return RecipesUtil.transform(originalUri, pattern, replacement)
-                    .map(newUri -> {
-                        attributes.remove(uriAttr.get());
-                        attributes.add(uriAttr.get().withValue(uriAttr.get().getValue().withValue(newUri)));
-                        return tag.withAttributes(attributes);
-                    })
-                    .orElse(tag);
-        }
-
-        return tag;
+        return tag.withAttributes(ListUtils.map(tag.getAttributes(), attr -> {
+            if (!"uri".equals(attr.getKey().getName())) {
+                return attr;
+            }
+            return RecipesUtil.transform(attr.getValue().getValue(), pattern, replacement)
+                    .map(newUri -> attr.withValue(attr.getValue().withValue(newUri)))
+                    .orElse(attr);
+        }));
     }
 }

--- a/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/customRecipes/internal/ChangeYamlComponentUriRecipe.java
+++ b/camel-upgrade-recipes/src/main/java/org/apache/camel/upgrade/customRecipes/internal/ChangeYamlComponentUriRecipe.java
@@ -16,13 +16,11 @@
  */
 package org.apache.camel.upgrade.customRecipes.internal;
 
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.RequiredArgsConstructor;
 import org.apache.camel.upgrade.AbstractCamelYamlVisitor;
 import org.apache.camel.upgrade.RecipesUtil;
 import org.openrewrite.ExecutionContext;
 import org.openrewrite.Option;
+import org.openrewrite.Preconditions;
 import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.yaml.JsonPathMatcher;
@@ -33,9 +31,6 @@ import java.util.regex.Pattern;
 /**
  * Transform component URIs in YAML DSL using regexp with capturing groups.
  */
-@EqualsAndHashCode(callSuper = false)
-@RequiredArgsConstructor
-@AllArgsConstructor
 public class ChangeYamlComponentUriRecipe extends Recipe {
 
     private static final JsonPathMatcher YAML_URI_MATCHER = new JsonPathMatcher("$..uri");
@@ -54,6 +49,22 @@ public class ChangeYamlComponentUriRecipe extends Recipe {
     )
     public String replacement;
 
+    public ChangeYamlComponentUriRecipe() {
+    }
+
+    public ChangeYamlComponentUriRecipe(String uriPattern, String replacement) {
+        this.uriPattern = uriPattern;
+        this.replacement = replacement;
+    }
+
+    public void setUriPattern(String uriPattern) {
+        this.uriPattern = uriPattern;
+    }
+
+    public void setReplacement(String replacement) {
+        this.replacement = replacement;
+    }
+
     @Override
     public String getDisplayName() {
         return "Change Camel component URI in YAML DSL";
@@ -68,7 +79,7 @@ public class ChangeYamlComponentUriRecipe extends Recipe {
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         Pattern pattern = Pattern.compile(uriPattern);
 
-        return new AbstractCamelYamlVisitor() {
+        return Preconditions.check(RecipesUtil.camelYamlDslPrecondition(), new AbstractCamelYamlVisitor() {
             @Override
             protected void clearLocalCache() {
                 // Nothing to clear
@@ -88,6 +99,6 @@ public class ChangeYamlComponentUriRecipe extends Recipe {
 
                 return e;
             }
-        };
+        });
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,6 @@
         <!-- Should be aligned to quarkus-updates - https://github.com/quarkusio/quarkus-updates/blob/main/pom.xml#L64 -->
         <rewrite-recipe-bom.version>3.24.0</rewrite-recipe-bom.version>
 
-        <lombok.version>1.18.42</lombok.version>
         <slf4j.version>1.7.36</slf4j.version>
 
         <!-- Http version used by the tests -->


### PR DESCRIPTION
## Summary

- **Fix #106**: `UpgradeSpringBoot3To4` no longer downgrades Java 21+ projects to Java 17. Replaced blind `ChangePropertyValue` calls with `JavaVersion17` recipe which uses floor semantics.
- **Fix #81**: All YAML DSL visitors now use `Preconditions.check()` with Camel root key detection, preventing modification of non-Camel YAML files (GitHub Actions workflows, Kubernetes manifests, Helm charts).
- **Remove Lombok**: Replaced with manual constructors/setters across 31 files. Lombok 1.18.42 is broken on JDK 25 — `@AllArgsConstructor`, `@Setter`, and `@EqualsAndHashCode` generate no code, causing recipe validation failures.
- **Fix LST collection patterns**: Replaced `stream().toList()`/`.collect()` and `new ArrayList<>()` copies with `ListUtils.map`/`flatMap`/`concat` on LST content to preserve referential equality and avoid phantom changes.
- **Parallel tests**: Added `forkCount=2C` to surefire for parallel test execution.

## Test plan

- [x] `UpgradeSpringBoot3To4Test` — Java 21 not downgraded, Java 11 upgraded to 17
- [x] `CamelSpringBoot413Test` — recipe validation passes (Lombok removal verified)
- [x] `CamelUpdate413Test#yamlDsl` + `yamlDslLeavesUnrelatedYamlAlone` — precondition refactoring works
- [x] `CamelUpdate415Test#dataFormatYamlDsl` — `dataFormats` root key recognized
- [x] `CamelUpdate419Test` — saga XML/YAML, route policy, test-infra POM all pass
- [x] `CamelUpdate46Test#beanPropertyChangedToProperties` — ListUtils + precondition
- [x] `CamelUpdate47Test#yamlDslLoadBalancer` — ListUtils + precondition