### PR TITLE
Fix #107: Narrow transform rename to DataType overloads only

### DIFF
--- a/camel-upgrade-recipes/src/main/resources/META-INF/rewrite/4.17.yaml
+++ b/camel-upgrade-recipes/src/main/resources/META-INF/rewrite/4.17.yaml
@@ -29,7 +29,11 @@ displayName: Migrates `camel 4.16` application to `camel 4.17`
 description: Migrates `camel 4.16` application to `camel 4.17`.
 recipeList:
   - org.openrewrite.java.ChangeMethodName:
-      methodPattern: "org.apache.camel.model.ProcessorDefinition#transform(..)"
+      methodPattern: "org.apache.camel.model.ProcessorDefinition transform(org.apache.camel.spi.DataType)"
+      newMethodName: "transformDataType"
+      matchOverrides: true
+  - org.openrewrite.java.ChangeMethodName:
+      methodPattern: "org.apache.camel.model.ProcessorDefinition transform(org.apache.camel.spi.DataType, org.apache.camel.spi.DataType)"
       newMethodName: "transformDataType"
       matchOverrides: true
   - org.apache.camel.upgrade.camel417.YamlTransform417Recipe

--- a/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelUpdate417Test.java
+++ b/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelUpdate417Test.java
@@ -110,6 +110,28 @@ public class CamelUpdate417Test implements RewriteTest {
      * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_17.html#_camel_core">Camel-core transform EIP</a>
      */
     @Test
+    void transformEipNotDataType() {
+        //language=java
+        rewriteRun(java(
+                """
+                import org.apache.camel.builder.RouteBuilder;
+
+                public class TransformRoute extends RouteBuilder {
+
+                    @Override
+                    public void configure() {
+                        from("direct:start")
+                            .transform(constant("Hello World"))
+                            .to("mock:result");
+                    }
+                }
+                """));
+    }
+
+    /**
+     * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_17.html#_camel_core">Camel-core transform EIP</a>
+     */
+    @Test
     void transformEip() {
         //language=java
         rewriteRun(java(


### PR DESCRIPTION
## Summary

- Narrow the 4.17 `ChangeMethodName` pattern from `transform(..)` (all overloads) to only match `transform(DataType)` and `transform(DataType, DataType)`
- Add `transformEipNotDataType()` test verifying `transform(Expression)` is not renamed

Fixes https://github.com/apache/camel-upgrade-recipes/issues/107

_Claude Code on behalf of Federico Mariani_