### PR TITLE
Document Camel 4.18.3 LTS recipes in README and release notes

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -25,6 +25,13 @@ $ mvn -U org.openrewrite.maven:rewrite-maven-plugin:run -Drewrite.recipeArtifact
 ```
 
 
+To upgrade to the latest version of Camel 4.18 (LTS), you can execute the following script:
+
+```
+$ mvn -U org.openrewrite.maven:rewrite-maven-plugin:run -Drewrite.recipeArtifactCoordinates=org.apache.camel.upgrade:camel-upgrade-recipes:LATEST -Drewrite.activeRecipes=org.apache.camel.upgrade.Camel418LTSMigrationRecipe
+```
+
+
 To apply specific recipes you can use the following script:
 
 ```

--- a/release_notes.adoc
+++ b/release_notes.adoc
@@ -6,6 +6,15 @@
 
 This is a release supporting Camel, Camel Quarkus and Camel Spring Boot 4.21.0 with the required upgrade recipes (described by the https://camel.apache.org/manual/camel-4x-upgrade-guide-4_21.html[migration guide]).
 
+This release also introduces migration recipes for *Camel 4.18.3 LTS*. A dedicated `Camel418LTSMigrationRecipe` is available for users staying on the 4.18 LTS line (see README for usage). The 4.18.3 recipes cover changes backported to the 4.18.x maintenance branch, primarily:
+
+* *Header renames* for camel-jgroups, camel-jira, camel-jgroups-raft, camel-shiro, camel-solr, camel-github2, camel-google-cloud (functions, secret-manager), camel-mongodb-gridfs, camel-openstack, camel-web3j, camel-lucene
+* *Saga EIP* structure changes (XML and YAML DSL)
+* *YAML DSL* `routePolicy` renamed to `routePolicyRef`
+* *camel-elasticsearch* `enableDocumentOnlyMode` header migration
+
+All recipes included in the 4.18.3 migration are also part of the 4.21.0 migration path — there are no 4.18.3-specific recipes missing from 4.21.0. For the detailed 4.18.3 migration coverage, see the <<4.18.3>> section below.
+
 === Safety Features
 
 All header rename recipes now include dependency-based preconditions using `ModuleHasDependency`. This ensures headers are only renamed when the corresponding Camel component is actually present in the project, preventing false positives and accidental renaming of unrelated headers.


### PR DESCRIPTION
## Summary

- Add Camel 4.18 LTS usage example to README (matching the existing 4.10 LTS pattern)
- Add 4.18.3 LTS summary to the 4.21.0 release notes section, listing the key migration topics covered (header renames, Saga EIP, routePolicy, elasticsearch)
- Confirm that all 4.18.3 recipes are a subset of 4.21.0 — nothing is missing from the main migration path

## Test plan

- [x] Verify README renders correctly with the new 4.18 LTS command example
- [x] Verify release_notes.adoc renders correctly with the new 4.18.3 LTS paragraph under 4.21.0

_Claude Code on behalf of Jiri Ondrusek_

🤖 Generated with [Claude Code](https://claude.com/claude-code)