### PR TITLE
Recipes bom upgrade and fix of suite test failures by dynamically expecting POM version upgrades

### DIFF
--- a/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/examples.yml
+++ b/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/examples.yml
@@ -38,3 +38,31 @@ examples:
       camel.main.include-non-singletons=something
       camel.main.warn-on-early-shutdown=something
     language: properties
+---
+type: specs.openrewrite.org/v1beta/example
+recipeName: org.apache.camel.upgrade.spring.UpgradeSpringBoot3To4
+examples:
+- description: ''
+  sources:
+  - before: |
+      <project>
+          <modelVersion>4.0.0</modelVersion>
+          <groupId>com.example</groupId>
+          <artifactId>test</artifactId>
+          <version>1.0.0</version>
+          <properties>
+              <java.version>11</java.version>
+          </properties>
+      </project>
+    after: |
+      <project>
+          <modelVersion>4.0.0</modelVersion>
+          <groupId>com.example</groupId>
+          <artifactId>test</artifactId>
+          <version>1.0.0</version>
+          <properties>
+              <java.version>17</java.version>
+          </properties>
+      </project>
+    path: pom.xml
+    language: xml

--- a/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelTestUtil.java
+++ b/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelTestUtil.java
@@ -20,6 +20,7 @@ import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.Parser;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.test.RecipeSpec;
+import org.openrewrite.test.SourceSpecs;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,6 +28,8 @@ import java.io.InputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
+
+import static org.openrewrite.maven.Assertions.pomXml;
 
 public class CamelTestUtil {
     public static final String PROPERTY_USE_RECIPE = "camelUpgradeRecipes-useRecipe";
@@ -217,6 +220,56 @@ public class CamelTestUtil {
                     </dependencies>
                 </project>
                 """.formatted(artifactId, version.getVersion());
+    }
+
+    /**
+     * Returns the target Camel version when running under a suite recipe that includes
+     * UpgradeDependencyVersion, or null when no version upgrade is expected.
+     */
+    private static String getTargetVersionFromRecipe() {
+        String useRecipe = System.getProperty(PROPERTY_USE_RECIPE);
+        if (useRecipe == null || useRecipe.isEmpty()) {
+            return null;
+        }
+        switch (useRecipe) {
+            case "org.apache.camel.upgrade.CamelMigrationRecipe":
+                return getCamelLatestVersion();
+            case "org.apache.camel.upgrade.Camel418LTSMigrationRecipe":
+                return getCamel418LtsVersion();
+            case "org.apache.camel.upgrade.Camel410LTSMigrationRecipe":
+                return getCamel410LtsVersion();
+            default:
+                return null;
+        }
+    }
+
+    public static boolean isRecipeOverridden() {
+        return getTargetVersionFromRecipe() != null;
+    }
+
+    /**
+     * Creates a pomXml SourceSpecs that expects the camel dependency version to be upgraded
+     * when running under a suite recipe (UpgradeDependencyVersion), or no POM change when
+     * running standalone.
+     */
+    public static SourceSpecs pomXmlSpec(String artifactId, CamelVersion sourceVersion) {
+        return pomXmlSpec(pomXmlWithDependency(artifactId, sourceVersion), sourceVersion.getVersion());
+    }
+
+    /**
+     * Creates a pomXml SourceSpecs from a raw POM string, expecting the camel dependency version
+     * to be upgraded when running under a suite recipe.
+     */
+    public static SourceSpecs pomXmlSpec(String pomBefore, String sourceVersion) {
+        String targetVersion = getTargetVersionFromRecipe();
+        if (targetVersion != null && !targetVersion.equals(sourceVersion)) {
+            String pomAfter = pomBefore.replace(
+                    "<version>" + sourceVersion + "</version>",
+                    "<version>" + targetVersion + "</version>"
+            );
+            return pomXml(pomBefore, pomAfter);
+        }
+        return pomXml(pomBefore);
     }
 
 }

--- a/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelUpdate418Test.java
+++ b/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelUpdate418Test.java
@@ -24,7 +24,6 @@ import org.openrewrite.test.TypeValidation;
 
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.java.Assertions.mavenProject;
-import static org.openrewrite.maven.Assertions.pomXml;
 
 //class has to stay public, because test is extended in project quarkus-updates
 public class CamelUpdate418Test implements RewriteTest {
@@ -42,7 +41,7 @@ public class CamelUpdate418Test implements RewriteTest {
      */
     @DocumentExample
     @Test
-    void testQdrantHeadersChange() {
+    void qdrantHeadersChange() {
         //language=java
         rewriteRun(java(
                 """
@@ -71,7 +70,7 @@ public class CamelUpdate418Test implements RewriteTest {
      * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_18.html#_camel_tahu">camel-tahu changes</a>
      */
     @Test
-    void testTahuChange() {
+    void tahuChange() {
         //language=java
         rewriteRun(java(
                 """
@@ -101,11 +100,11 @@ public class CamelUpdate418Test implements RewriteTest {
     }
 
     @Test
-    void testKafkaHeadersMigration() {
+    void kafkaHeadersMigration() {
         //language=java
         rewriteRun(
                 mavenProject("test-kafka",
-                        pomXml(CamelTestUtil.pomXmlWithDependency("camel-kafka", CamelTestUtil.CamelVersion.v4_17)),
+                        CamelTestUtil.pomXmlSpec("camel-kafka", CamelTestUtil.CamelVersion.v4_17),
                         java(
                                 """
                                 import org.apache.camel.Exchange;
@@ -141,11 +140,11 @@ public class CamelUpdate418Test implements RewriteTest {
     }
 
     @Test
-    void testDnsHeadersMigrationJava() {
+    void dnsHeadersMigrationJava() {
         //language=java
         rewriteRun(
                 mavenProject("test-dns",
-                        pomXml(CamelTestUtil.pomXmlWithDependency("camel-dns", CamelTestUtil.CamelVersion.v4_17)),
+                        CamelTestUtil.pomXmlSpec("camel-dns", CamelTestUtil.CamelVersion.v4_17),
                         java(
                                 """
                                 import org.apache.camel.Exchange;
@@ -187,11 +186,11 @@ public class CamelUpdate418Test implements RewriteTest {
     }
 
     @Test
-    void testSalesforceHeadersMigrationJava() {
+    void salesforceHeadersMigrationJava() {
         //language=java
         rewriteRun(
                 mavenProject("test-salesforce",
-                        pomXml(CamelTestUtil.pomXmlWithDependency("camel-salesforce", CamelTestUtil.CamelVersion.v4_17)),
+                        CamelTestUtil.pomXmlSpec("camel-salesforce", CamelTestUtil.CamelVersion.v4_17),
                         java(
                                 """
                                 import org.apache.camel.Exchange;

--- a/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelUpdate418_1Test.java
+++ b/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelUpdate418_1Test.java
@@ -17,6 +17,7 @@
 package org.apache.camel.upgrade;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.test.TypeValidation;
@@ -39,8 +40,9 @@ public class CamelUpdate418_1Test implements RewriteTest {
     /**
      * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_saga_eip">Saga EIP</a>
      */
+    @DocumentExample
     @Test
-    void testSagaEipXml() {
+    void sagaEipXml() {
         //language=xml
         rewriteRun(xml(
           """
@@ -91,7 +93,7 @@ public class CamelUpdate418_1Test implements RewriteTest {
      * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_saga_eip">Saga EIP</a>
      */
     @Test
-    void testSagaEipYaml() {
+    void sagaEipYaml() {
         //language=yaml
         rewriteRun(yaml(
           """
@@ -126,7 +128,7 @@ public class CamelUpdate418_1Test implements RewriteTest {
      * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_19.html#_camel_yaml_io_camel_xml_io">YAML DSL</a>
      */
     @Test
-    void testYamlDslRoutePolicyRename() {
+    void yamlDslRoutePolicyRename() {
         //language=yaml
         rewriteRun(yaml(
                 """

--- a/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelUpdate418_3Test.java
+++ b/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelUpdate418_3Test.java
@@ -17,16 +17,12 @@
 package org.apache.camel.upgrade;
 
 import org.junit.jupiter.api.Test;
-import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.test.TypeValidation;
 
 import static org.openrewrite.java.Assertions.java;
 import static org.openrewrite.java.Assertions.mavenProject;
-import static org.openrewrite.maven.Assertions.pomXml;
-import static org.openrewrite.xml.Assertions.xml;
-import static org.openrewrite.yaml.Assertions.yaml;
 
 /**
  * Tests for migrating from Camel 4.18.1 to 4.18.3.
@@ -43,11 +39,11 @@ public class CamelUpdate418_3Test implements RewriteTest {
     }
 
     @Test
-    void testLuceneHeadersMigrationJava() {
+    void luceneHeadersMigrationJava() {
         //language=java
         rewriteRun(
                 mavenProject("test-lucene",
-                        pomXml(CamelTestUtil.pomXmlWithDependency("camel-lucene", CamelTestUtil.CamelVersion.v4_18)),
+                        CamelTestUtil.pomXmlSpec("camel-lucene", CamelTestUtil.CamelVersion.v4_18),
                         java(
                         """
                         import org.apache.camel.Exchange;
@@ -89,11 +85,11 @@ public class CamelUpdate418_3Test implements RewriteTest {
     }
 
     @Test
-    void testJGroupsHeadersMigration() {
+    void jGroupsHeadersMigration() {
         //language=java
         rewriteRun(
                 mavenProject("test-jgroups",
-                        pomXml(CamelTestUtil.pomXmlWithDependency("camel-jgroups", CamelTestUtil.CamelVersion.v4_18)),
+                        CamelTestUtil.pomXmlSpec("camel-jgroups", CamelTestUtil.CamelVersion.v4_18),
                         java(
                         """
                         import org.apache.camel.Exchange;
@@ -131,11 +127,11 @@ public class CamelUpdate418_3Test implements RewriteTest {
     }
 
     @Test
-    void testJiraHeadersMigrationJava() {
+    void jiraHeadersMigrationJava() {
         //language=java
         rewriteRun(
                 mavenProject("test-jira",
-                        pomXml(
+                        CamelTestUtil.pomXmlSpec(
                         """
                         <project>
                             <groupId>com.example</groupId>
@@ -165,7 +161,7 @@ public class CamelUpdate418_3Test implements RewriteTest {
                                 </dependency>
                             </dependencies>
                         </project>
-                        """
+                        """, CamelTestUtil.CamelVersion.v4_18.getVersion()
                         ),
                         java(
                         """
@@ -210,11 +206,11 @@ public class CamelUpdate418_3Test implements RewriteTest {
     }
 
     @Test
-    void testJGroupsRaftHeadersMigration() {
+    void jGroupsRaftHeadersMigration() {
         //language=java
         rewriteRun(
                 mavenProject("test-jgroups-raft",
-                        pomXml(CamelTestUtil.pomXmlWithDependency("camel-jgroups-raft", CamelTestUtil.CamelVersion.v4_18)),
+                        CamelTestUtil.pomXmlSpec("camel-jgroups-raft", CamelTestUtil.CamelVersion.v4_18),
                         java(
                         """
                         import org.apache.camel.Exchange;
@@ -252,11 +248,11 @@ public class CamelUpdate418_3Test implements RewriteTest {
     }
 
     @Test
-    void testShiroHeadersMigration() {
+    void shiroHeadersMigration() {
         //language=java
         rewriteRun(
                 mavenProject("test-shiro",
-                        pomXml(CamelTestUtil.pomXmlWithDependency("camel-shiro", CamelTestUtil.CamelVersion.v4_18)),
+                        CamelTestUtil.pomXmlSpec("camel-shiro", CamelTestUtil.CamelVersion.v4_18),
                         java(
                         """
                         import org.apache.camel.Exchange;
@@ -294,11 +290,11 @@ public class CamelUpdate418_3Test implements RewriteTest {
     }
 
     @Test
-    void testSolrHeadersMigration() {
+    void solrHeadersMigration() {
         //language=java
         rewriteRun(
                 mavenProject("test-solr",
-                        pomXml(CamelTestUtil.pomXmlWithDependency("camel-solr", CamelTestUtil.CamelVersion.v4_18)),
+                        CamelTestUtil.pomXmlSpec("camel-solr", CamelTestUtil.CamelVersion.v4_18),
                         java(
                         """
                         import org.apache.camel.Exchange;
@@ -340,11 +336,11 @@ public class CamelUpdate418_3Test implements RewriteTest {
     }
 
     @Test
-    void testGitHub2HeadersMigrationJava() {
+    void gitHub2HeadersMigrationJava() {
         //language=java
         rewriteRun(
                 mavenProject("test-github",
-                        pomXml(
+                        CamelTestUtil.pomXmlSpec(
                         """
                         <project>
                             <groupId>com.example</groupId>
@@ -361,7 +357,7 @@ public class CamelUpdate418_3Test implements RewriteTest {
                                 </dependency>
                             </dependencies>
                         </project>
-                        """
+                        """, CamelTestUtil.CamelVersion.v4_18.getVersion()
                         ),
                         java(
                         """
@@ -398,11 +394,11 @@ public class CamelUpdate418_3Test implements RewriteTest {
     }
 
     @Test
-    void testGoogleCloudHeadersMigrationJava() {
+    void googleCloudHeadersMigrationJava() {
         //language=java
         rewriteRun(
                 mavenProject("test-google-cloud",
-                        pomXml(CamelTestUtil.pomXmlWithDependency("camel-google-functions", CamelTestUtil.CamelVersion.v4_18)),
+                        CamelTestUtil.pomXmlSpec("camel-google-functions", CamelTestUtil.CamelVersion.v4_18),
                         java(
                         """
                         import org.apache.camel.Exchange;
@@ -438,11 +434,11 @@ public class CamelUpdate418_3Test implements RewriteTest {
     }
 
     @Test
-    void testMongoDbGridFsHeadersMigrationJava() {
+    void mongoDbGridFsHeadersMigrationJava() {
         //language=java
         rewriteRun(
                 mavenProject("test-mongodb",
-                        pomXml(CamelTestUtil.pomXmlWithDependency("camel-mongodb-gridfs", CamelTestUtil.CamelVersion.v4_18)),
+                        CamelTestUtil.pomXmlSpec("camel-mongodb-gridfs", CamelTestUtil.CamelVersion.v4_18),
                         java(
                         """
                         import org.apache.camel.Exchange;
@@ -478,11 +474,11 @@ public class CamelUpdate418_3Test implements RewriteTest {
     }
 
     @Test
-    void testOpenstackHeadersMigrationJava() {
+    void openstackHeadersMigrationJava() {
         //language=java
         rewriteRun(
                 mavenProject("test-openstack",
-                        pomXml(CamelTestUtil.pomXmlWithDependency("camel-openstack", CamelTestUtil.CamelVersion.v4_18)),
+                        CamelTestUtil.pomXmlSpec("camel-openstack", CamelTestUtil.CamelVersion.v4_18),
                         java(
                                 """
                                 import org.apache.camel.Exchange;
@@ -530,11 +526,11 @@ public class CamelUpdate418_3Test implements RewriteTest {
     }
 
     @Test
-    void testWeb3jHeadersMigrationJava() {
+    void web3jHeadersMigrationJava() {
         //language=java
         rewriteRun(
                 mavenProject("test-web3j",
-                        pomXml(CamelTestUtil.pomXmlWithDependency("camel-web3j", CamelTestUtil.CamelVersion.v4_18)),
+                        CamelTestUtil.pomXmlSpec("camel-web3j", CamelTestUtil.CamelVersion.v4_18),
                         java(
                                 """
                                 import org.apache.camel.Exchange;

--- a/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelUpdate419Test.java
+++ b/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelUpdate419Test.java
@@ -108,7 +108,7 @@ public class CamelUpdate419Test implements RewriteTest {
      */
     @Test
     void sagaEipXml() {
-        new CamelUpdate418_1Test().testSagaEipXml();
+        new CamelUpdate418_1Test().sagaEipXml();
     }
 
     /**
@@ -116,7 +116,7 @@ public class CamelUpdate419Test implements RewriteTest {
      */
     @Test
     void sagaEipYaml() {
-        new CamelUpdate418_1Test().testSagaEipYaml();
+        new CamelUpdate418_1Test().sagaEipYaml();
     }
 
 
@@ -191,7 +191,7 @@ public class CamelUpdate419Test implements RewriteTest {
      */
     @Test
     void yamlDslRoutePolicyRename() {
-        new CamelUpdate418_1Test().testYamlDslRoutePolicyRename();
+        new CamelUpdate418_1Test().yamlDslRoutePolicyRename();
     }
     /**
      * <a href="https://camel.apache.org/manual/camel-4x-upgrade-guide-4_18.html#_camel_bom">camel-bom</a>

--- a/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelUpdate421Test.java
+++ b/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/CamelUpdate421Test.java
@@ -17,6 +17,7 @@
 package org.apache.camel.upgrade;
 
 import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
 import org.openrewrite.test.RecipeSpec;
 import org.openrewrite.test.RewriteTest;
 import org.openrewrite.test.TypeValidation;
@@ -42,37 +43,66 @@ public class CamelUpdate421Test implements RewriteTest {
                 .expectedCyclesThatMakeChanges(1);
     }
 
+    @DocumentExample
     @Test
-    void testJGroupsHeadersMigration() {
-        new CamelUpdate418_3Test().testJGroupsHeadersMigration();
+    void removeReifierStrategyImport() {
+        //language=java
+        rewriteRun(
+                java(
+                """
+                import org.apache.camel.builder.RouteBuilder;
+                import org.apache.camel.spi.ReifierStrategy;
+
+                class Test extends RouteBuilder {
+                    public void configure() {
+                        from("direct:start").to("log:test");
+                    }
+                }
+                """,
+                """
+                import org.apache.camel.builder.RouteBuilder;
+
+                class Test extends RouteBuilder {
+                    public void configure() {
+                        from("direct:start").to("log:test");
+                    }
+                }
+                """
+                )
+        );
     }
 
     @Test
-    void testDnsHeadersMigrationJava() {
-        new CamelUpdate418Test().testDnsHeadersMigrationJava();
+    void jGroupsHeadersMigration() {
+        new CamelUpdate418_3Test().jGroupsHeadersMigration();
     }
 
     @Test
-    void testJiraHeadersMigrationJava() {
-        new CamelUpdate418_3Test().testJiraHeadersMigrationJava();
+    void dnsHeadersMigrationJava() {
+        new CamelUpdate418Test().dnsHeadersMigrationJava();
     }
 
     @Test
-    void testOpenstackHeadersMigrationJava() {
-        new CamelUpdate418_3Test().testOpenstackHeadersMigrationJava();
+    void jiraHeadersMigrationJava() {
+        new CamelUpdate418_3Test().jiraHeadersMigrationJava();
     }
 
     @Test
-    void testWeb3jHeadersMigrationJava() {
-        new CamelUpdate418_3Test().testWeb3jHeadersMigrationJava();
+    void openstackHeadersMigrationJava() {
+        new CamelUpdate418_3Test().openstackHeadersMigrationJava();
     }
 
     @Test
-    void testCouchdbHeadersMigration() {
+    void web3jHeadersMigrationJava() {
+        new CamelUpdate418_3Test().web3jHeadersMigrationJava();
+    }
+
+    @Test
+    void couchdbHeadersMigration() {
         //language=java
         rewriteRun(
                 mavenProject("test-couchdb",
-                        pomXml(CamelTestUtil.pomXmlWithDependency("camel-couchdb", CamelTestUtil.CamelVersion.v4_20)),
+                        CamelTestUtil.pomXmlSpec("camel-couchdb", CamelTestUtil.CamelVersion.v4_20),
                         java(
                         """
                         import org.apache.camel.Exchange;
@@ -110,11 +140,11 @@ public class CamelUpdate421Test implements RewriteTest {
     }
 
     @Test
-    void testCouchbaseHeadersMigration() {
+    void couchbaseHeadersMigration() {
         //language=java
         rewriteRun(
                 mavenProject("test-couchbase",
-                        pomXml(CamelTestUtil.pomXmlWithDependency("camel-couchbase", CamelTestUtil.CamelVersion.v4_20)),
+                        CamelTestUtil.pomXmlSpec("camel-couchbase", CamelTestUtil.CamelVersion.v4_20),
                         java(
                         """
                         import org.apache.camel.Exchange;
@@ -152,43 +182,43 @@ public class CamelUpdate421Test implements RewriteTest {
     }
 
     @Test
-    void testJGroupsRaftHeadersMigration() {
-        new CamelUpdate418_3Test().testJGroupsRaftHeadersMigration();
+    void jGroupsRaftHeadersMigration() {
+        new CamelUpdate418_3Test().jGroupsRaftHeadersMigration();
     }
 
     @Test
-    void testShiroHeadersMigration() {
-        new CamelUpdate418_3Test().testShiroHeadersMigration();
+    void shiroHeadersMigration() {
+        new CamelUpdate418_3Test().shiroHeadersMigration();
     }
 
     @Test
-    void testSolrHeadersMigration() {
-        new CamelUpdate418_3Test().testSolrHeadersMigration();
+    void solrHeadersMigration() {
+        new CamelUpdate418_3Test().solrHeadersMigration();
     }
 
     @Test
-    void testGitHub2HeadersMigrationJava() {
-        new CamelUpdate418_3Test().testGitHub2HeadersMigrationJava();
+    void gitHub2HeadersMigrationJava() {
+        new CamelUpdate418_3Test().gitHub2HeadersMigrationJava();
     }
 
     @Test
-    void testGoogleCloudHeadersMigrationJava() {
-        new CamelUpdate418_3Test().testGoogleCloudHeadersMigrationJava();
+    void googleCloudHeadersMigrationJava() {
+        new CamelUpdate418_3Test().googleCloudHeadersMigrationJava();
     }
 
     //todo more google - vision, text-to=speech, speech-to-text
 
     @Test
-    void testMongoDbGridFsHeadersMigrationJava() {
-        new CamelUpdate418_3Test().testMongoDbGridFsHeadersMigrationJava();
+    void mongoDbGridFsHeadersMigrationJava() {
+        new CamelUpdate418_3Test().mongoDbGridFsHeadersMigrationJava();
     }
 
     @Test
-    void testIrcHeadersMigrationJava() {
+    void ircHeadersMigrationJava() {
         //language=java
         rewriteRun(
                 mavenProject("test-irc",
-                        pomXml(CamelTestUtil.pomXmlWithDependency("camel-irc", CamelTestUtil.CamelVersion.v4_20)),
+                        CamelTestUtil.pomXmlSpec("camel-irc", CamelTestUtil.CamelVersion.v4_20),
                         java(
                         """
                         import org.apache.camel.Exchange;
@@ -224,15 +254,15 @@ public class CamelUpdate421Test implements RewriteTest {
     }
 
     @Test
-    void testPreconditionBlocksWithoutDependency() {
+    void preconditionBlocksWithoutDependency() {
         // Test that the Kafka recipe does NOT run when camel-kafka dependency is absent
         // This verifies the ModuleHasDependency precondition works correctly
         // Using camel-core instead of camel-kafka means the precondition will block the recipe
         //language=java
         rewriteRun(
-                spec -> spec.expectedCyclesThatMakeChanges(0),
+                spec -> spec.expectedCyclesThatMakeChanges(CamelTestUtil.isRecipeOverridden() ? 1 : 0),
                 mavenProject("test-negative",
-                        pomXml(CamelTestUtil.pomXmlWithDependency("camel-core", CamelTestUtil.CamelVersion.v4_20)),
+                        CamelTestUtil.pomXmlSpec("camel-core", CamelTestUtil.CamelVersion.v4_20),
                         java(
                         """
                         import org.apache.camel.Exchange;
@@ -252,35 +282,7 @@ public class CamelUpdate421Test implements RewriteTest {
     }
 
     @Test
-    void testRemoveReifierStrategyImport() {
-        //language=java
-        rewriteRun(
-                java(
-                """
-                import org.apache.camel.builder.RouteBuilder;
-                import org.apache.camel.spi.ReifierStrategy;
-
-                class Test extends RouteBuilder {
-                    public void configure() {
-                        from("direct:start").to("log:test");
-                    }
-                }
-                """,
-                """
-                import org.apache.camel.builder.RouteBuilder;
-
-                class Test extends RouteBuilder {
-                    public void configure() {
-                        from("direct:start").to("log:test");
-                    }
-                }
-                """
-                )
-        );
-    }
-
-    @Test
-    void testRemoveZooWordEmbeddingPredictorImport() {
+    void removeZooWordEmbeddingPredictorImport() {
         //language=java
         rewriteRun(
                 java(
@@ -308,12 +310,12 @@ public class CamelUpdate421Test implements RewriteTest {
     }
 
     @Test
-    void testLuceneHeadersMigrationJava() {
-        new CamelUpdate418_3Test().testLuceneHeadersMigrationJava();
+    void luceneHeadersMigrationJava() {
+        new CamelUpdate418_3Test().luceneHeadersMigrationJava();
     }
 
     @Test
-    void testRemoveCamelStompDependency() {
+    void removeCamelStompDependency() {
         //language=xml
         rewriteRun(
                 pomXml(
@@ -349,7 +351,7 @@ public class CamelUpdate421Test implements RewriteTest {
     }
 
     @Test
-    void testRemoveCamelAwsXrayDependency() {
+    void removeCamelAwsXrayDependency() {
         //language=xml
         rewriteRun(
                 pomXml(
@@ -385,7 +387,7 @@ public class CamelUpdate421Test implements RewriteTest {
     }
 
     @Test
-    void testRemoveCamelGuavaEventbusDependency() {
+    void removeCamelGuavaEventbusDependency() {
         //language=xml
         rewriteRun(
                 pomXml(
@@ -421,7 +423,7 @@ public class CamelUpdate421Test implements RewriteTest {
     }
 
     @Test
-    void testRemoveCamelGrapeDependency() {
+    void removeCamelGrapeDependency() {
         //language=xml
         rewriteRun(
                 pomXml(
@@ -457,7 +459,7 @@ public class CamelUpdate421Test implements RewriteTest {
     }
 
     @Test
-    void testRemoveCamelElytronDependency() {
+    void removeCamelElytronDependency() {
         //language=xml
         rewriteRun(
                 pomXml(
@@ -493,11 +495,11 @@ public class CamelUpdate421Test implements RewriteTest {
     }
 
     @Test
-    void testMigrateAws2S3ListObjectsApi() {
+    void migrateAws2S3ListObjectsApi() {
         //language=java
         rewriteRun(
                 mavenProject("test-aws2-s3",
-                        pomXml(CamelTestUtil.pomXmlWithDependency("camel-aws2-s3", CamelTestUtil.CamelVersion.v4_20)),
+                        CamelTestUtil.pomXmlSpec("camel-aws2-s3", CamelTestUtil.CamelVersion.v4_20),
                         java(
                         """
                         import software.amazon.awssdk.services.s3.model.ListObjectsRequest;
@@ -527,7 +529,7 @@ public class CamelUpdate421Test implements RewriteTest {
     }
 
     @Test
-    void testRemoveCamelGithubDependency() {
+    void removeCamelGithubDependency() {
         //language=xml
         rewriteRun(
                 pomXml(
@@ -563,7 +565,7 @@ public class CamelUpdate421Test implements RewriteTest {
     }
 
     @Test
-    void testErrorRegistryPropertiesFile() {
+    void errorRegistryPropertiesFile() {
         //language=properties
         rewriteRun(
                 properties(

--- a/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/versions/CamelUpdate418LtsVersionTest.java
+++ b/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/versions/CamelUpdate418LtsVersionTest.java
@@ -18,11 +18,9 @@ package org.apache.camel.upgrade.versions;
 
 import org.apache.camel.upgrade.AbstractCamelUpdateVersionTest;
 import org.apache.camel.upgrade.CamelTestUtil;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 //class has to stay public, because test is extended in project quarkus-updates
-@Disabled //until 4.18.3 is released
 @EnabledIfSystemProperty(named = CamelTestUtil.PROPERTY_USE_RECIPE, matches = "org.apache.camel.upgrade.Camel418LTSMigrationRecipe")
 public class CamelUpdate418LtsVersionTest extends AbstractCamelUpdateVersionTest {
 

--- a/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/versions/CamelUpdateLatestVersionTest.java
+++ b/camel-upgrade-recipes/src/test/java/org/apache/camel/upgrade/versions/CamelUpdateLatestVersionTest.java
@@ -18,10 +18,8 @@ package org.apache.camel.upgrade.versions;
 
 import org.apache.camel.upgrade.AbstractCamelUpdateVersionTest;
 import org.apache.camel.upgrade.CamelTestUtil;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
-@Disabled //todo investigate properly why is failing on CI
 @EnabledIfSystemProperty(named = CamelTestUtil.PROPERTY_USE_RECIPE, matches = "org.apache.camel.upgrade.CamelMigrationRecipe")
 //class has to stay public, because test is extended in project quarkus-updates
 public class CamelUpdateLatestVersionTest extends AbstractCamelUpdateVersionTest {

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
         <spring-batch-version>6.0.3</spring-batch-version>
 
         <!-- Should be aligned to quarkus-updates - https://github.com/quarkusio/quarkus-updates/blob/main/pom.xml#L64 -->
-        <rewrite-recipe-bom.version>3.24.0</rewrite-recipe-bom.version>
+        <rewrite-recipe-bom.version>3.31.0</rewrite-recipe-bom.version>
 
         <slf4j.version>1.7.36</slf4j.version>
 


### PR DESCRIPTION
- Bumped rewrite-recipe-bom to 3.31.0 to align with quarkus updates
- Re-enabled the version tests.
- Tests running under CamelUpdateLatestTestSuite or CamelUpdate418LtsTestSuite failed because the suite recipe includes UpgradeDependencyVersion, which changes POM versions. Added pomXmlSpec() helpers to CamelTestUtil that detect the active suite recipe and adjust expected POM output accordingly. 