### PR TITLE
Add Camel Spring Boot 4.18 LTS migration recipe

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -32,6 +32,20 @@ $ mvn -U org.openrewrite.maven:rewrite-maven-plugin:run -Drewrite.recipeArtifact
 ```
 
 
+To upgrade a Camel Spring Boot application to the latest version:
+
+```
+$ mvn -U org.openrewrite.maven:rewrite-maven-plugin:run -Drewrite.recipeArtifactCoordinates=org.apache.camel.upgrade:camel-spring-boot-upgrade-recipes:LATEST -Drewrite.activeRecipes=org.apache.camel.upgrade.CamelSpringBootMigrationRecipe
+```
+
+
+To upgrade a Camel Spring Boot application to the 4.18 LTS (staying on Spring Boot 3.x):
+
+```
+$ mvn -U org.openrewrite.maven:rewrite-maven-plugin:run -Drewrite.recipeArtifactCoordinates=org.apache.camel.upgrade:camel-spring-boot-upgrade-recipes:LATEST -Drewrite.activeRecipes=org.apache.camel.upgrade.CamelSpringBoot418LTSMigrationRecipe
+```
+
+
 To apply specific recipes you can use the following script:
 
 ```

--- a/camel-spring-boot-upgrade-recipes/pom.xml
+++ b/camel-spring-boot-upgrade-recipes/pom.xml
@@ -31,6 +31,18 @@
     <name>Camel Spring Boot Upgrades Recipes</name>
     <description>Migration recipes (using openrewrite) for Camel Spring Boot to make Maven migrations easier</description>
 
+    <properties>
+        <!-- versions for camel-spring-boot latest, has to be kept aligned to the latest camel-spring-boot release -->
+        <spring-boot-version>4.1.0</spring-boot-version>
+        <springframework-version>7.0.8</springframework-version>
+        <spring-security-version>7.1.0</spring-security-version>
+        <spring-batch-version>6.0.4</spring-batch-version>
+
+        <!-- Spring versions for CSB 4.18 LTS, has to be kept aligned to camel-spring-boot 4.18.x -->
+        <spring-boot-4.18-lts-version>3.5.16</spring-boot-4.18-lts-version>
+        <springframework-4.18-lts-version>6.2.19</springframework-4.18-lts-version>
+    </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>

--- a/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/4.18LTS.yaml
+++ b/camel-spring-boot-upgrade-recipes/src/main/resources/META-INF/rewrite/4.18LTS.yaml
@@ -1,0 +1,73 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: org.apache.camel.upgrade.CamelSpringBoot418LTSMigrationRecipe
+displayName: Migrate to Camel Spring Boot 4.18 LTS
+description: >-
+  Migrates Camel Spring Boot applications to 4.18 LTS.
+  This recipe aggregates all migration steps from 4.9 to 4.18.3
+  while keeping Spring Boot on the 3.x line.
+recipeList:
+  - org.apache.camel.upgrade.camel418_3.CamelMigrationRecipe
+  - org.apache.camel.upgrade.camel418_1.CamelMigrationRecipe
+  - org.apache.camel.upgrade.camel418.CamelSpringBootMigrationRecipe
+  - org.apache.camel.upgrade.UpdateCamelSpringBootPropertiesAndYamlKeys
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: '*camel*'
+      artifactId: 'camel-spring-boot-bom'
+      newVersion: @camel4.18-lts-version@
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: 'org.apache.camel.springboot'
+      artifactId: 'spring-boot'
+      newVersion: @camel4.18-lts-version@
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: 'org.apache.camel.springboot'
+      artifactId: 'camel-spring-boot-dependencies'
+      newVersion: @camel4.18-lts-version@
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: 'org.apache.camel'
+      artifactId: '*'
+      newVersion: @camel4.18-lts-version@
+  - org.openrewrite.maven.UpgradePluginVersion:
+      groupId: 'org.apache.camel'
+      artifactId: '*'
+      newVersion: @camel4.18-lts-version@
+  - org.openrewrite.maven.UpgradeParentVersion:
+      groupId: 'org.apache.camel'
+      artifactId: '*'
+      newVersion: @camel4.18-lts-version@
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: camel.version
+      newValue: @camel4.18-lts-version@
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: org.springframework.boot
+      artifactId: "*"
+      newVersion: @spring-boot-4.18-lts-version@
+      overrideManagedVersion: false
+  - org.openrewrite.maven.UpgradePluginVersion:
+      groupId: org.springframework.boot
+      artifactId: spring-boot-maven-plugin
+      newVersion: @spring-boot-4.18-lts-version@
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: org.springframework
+      artifactId: "*"
+      newVersion: @springframework-4.18-lts-version@
+  - org.openrewrite.maven.UpgradeParentVersion:
+      groupId: org.springframework.boot
+      artifactId: spring-boot-starter-parent
+      newVersion: @spring-boot-4.18-lts-version@

--- a/pom.xml
+++ b/pom.xml
@@ -118,12 +118,6 @@
         <tahu-version>1.0.18</tahu-version>
         <jspecify-version>1.0.0</jspecify-version>
 
-        <!-- versions for camel-spring-boot -->
-        <spring-boot-version>4.1.0</spring-boot-version>
-        <springframework-version>7.0.8</springframework-version>
-        <spring-security-version>7.1.0</spring-security-version>
-        <spring-batch-version>6.0.4</spring-batch-version>
-
         <!-- Should be aligned to quarkus-updates - https://github.com/quarkusio/quarkus-updates/blob/main/pom.xml#L64 -->
         <rewrite-recipe-bom.version>3.31.0</rewrite-recipe-bom.version>
 


### PR DESCRIPTION
## Summary
- Add `CamelSpringBoot418LTSMigrationRecipe` so Camel Spring Boot users can upgrade to the 4.18 LTS line while staying on Spring Boot 3.x
- Move Spring Boot version properties (`spring-boot-version`, `springframework-version`, `spring-security-version`, `spring-batch-version`) from the parent POM into `camel-spring-boot-upgrade-recipes/pom.xml` where they belong
- Document CSB latest and CSB 4.18 LTS upgrade commands in README

## Test plan
- [x] `mvn clean install` passes
- [x] Tested LTS recipe against a CSB 4.14 app: upgrades to Camel 4.18.3 + Spring Boot 3.5.16, does NOT apply 4.19+ migrations (no JUnit 5→6, no Spring Boot 3→4)
- [x] Tested latest recipe against the same app: upgrades to Camel 4.21 + Spring Boot 4.x + JUnit 6 as expected